### PR TITLE
Don't filter out resolver rules associations by name, but only use resolver rule id and vpc id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Don't try to find resolver rules associations filtering by association name, but only use resolver rule id and vpc id.
+
 ## [0.1.0] - 2023-01-24
 
 ### Added

--- a/pkg/aws/resolverclient.go
+++ b/pkg/aws/resolverclient.go
@@ -275,15 +275,14 @@ func (a *AWSResolver) GetResolverRuleByName(ctx context.Context, resolverRuleNam
 	return resolver.ResolverRule{}, &resolver.ResolverRuleNotFoundError{}
 }
 
+// AssociateResolverRuleWithContext creates an association between a resolver rule and a VPC.
+// It will try to find an existing association for that Resolver Rule and VPC, and only create a new association if it
+// does not find any.
 func (a *AWSResolver) AssociateResolverRuleWithContext(ctx context.Context, logger logr.Logger, associationName, vpcId, resolverRuleId string) error {
-	logger = logger.WithValues("resolverRuleId", resolverRuleId, "vpcId", vpcId, "associationName", associationName)
+	logger = logger.WithValues("resolverRuleId", resolverRuleId, "vpcId", vpcId)
 	logger.Info("Checking if Resolver Rule is already associated to VPC")
 	listResolverRuleAssociationsResponse, err := a.client.ListResolverRuleAssociationsWithContext(ctx, &route53resolver.ListResolverRuleAssociationsInput{
 		Filters: []*route53resolver.Filter{
-			{
-				Name:   aws.String("Name"),
-				Values: aws.StringSlice([]string{associationName}),
-			},
 			{
 				Name:   aws.String("ResolverRuleId"),
 				Values: aws.StringSlice([]string{resolverRuleId}),


### PR DESCRIPTION
### What this PR does / why we need it

Don't filter out resolver rules associations by name, but only use resolver rule id and vpc id. That way, it doesn't matter if the association was created by the operator or manually. The operator will find it and use it if it's already there.

### Checklist

- [X] Update changelog in CHANGELOG.md.
