### PR TITLE
Revert seccomp profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fix
+
+- Revert seccomp profile.
+
 ## [0.2.0] - 2023-02-08
 
 ### Added

--- a/helm/aws-resolver-rules-operator/templates/deployment.yaml
+++ b/helm/aws-resolver-rules-operator/templates/deployment.yaml
@@ -24,9 +24,6 @@ spec:
       securityContext:
         runAsUser: {{ .Values.pod.user.id }}
         runAsGroup: {{ .Values.pod.group.id }}
-        {{- with .Values.podSecurityContext }}
-          {{- . | toYaml | nindent 8 }}
-        {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.registry }}/{{ .Values.image.name }}:{{ .Values.image.tag }}"
@@ -45,10 +42,6 @@ spec:
             - --dns-server-region={{ .Values.dnsServerRegion }}
             - --dns-server-vpc-id={{ .Values.dnsServerVpcId }}
             - --basedomain={{ .Values.baseDomain }}
-          securityContext:
-            {{- with .Values.securityContext }}
-              {{- . | toYaml | nindent 10 }}
-            {{- end }}
           resources:
             requests:
               cpu: 100m

--- a/helm/aws-resolver-rules-operator/templates/psp.yaml
+++ b/helm/aws-resolver-rules-operator/templates/psp.yaml
@@ -4,8 +4,6 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ include "resource.psp.name" . }}
-  annotations:
-    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'runtime/default'
   labels:
     {{- include "labels.common" . | nindent 4 }}
 spec:

--- a/helm/aws-resolver-rules-operator/values.schema.json
+++ b/helm/aws-resolver-rules-operator/values.schema.json
@@ -54,19 +54,6 @@
                 }
             }
         },
-        "podSecurityContext": {
-            "type": "object",
-            "properties": {
-                "seccompProfile": {
-                    "type": "object",
-                    "properties": {
-                        "type": {
-                            "type": "string"
-                        }
-                    }
-                }
-            }
-        },
         "project": {
             "type": "object",
             "properties": {
@@ -75,19 +62,6 @@
                 },
                 "commit": {
                     "type": "string"
-                }
-            }
-        },
-        "securityContext": {
-            "type": "object",
-            "properties": {
-                "seccompProfile": {
-                    "type": "object",
-                    "properties": {
-                        "type": {
-                            "type": "string"
-                        }
-                    }
                 }
             }
         }

--- a/helm/aws-resolver-rules-operator/values.yaml
+++ b/helm/aws-resolver-rules-operator/values.yaml
@@ -37,13 +37,3 @@ dnsServerIAMRoleExternalId: ""
 # Base domain used for the workload clusters created on the MC where this controller is deployed.
 # Normally we prepend the workload cluster name to this, i.e. my-cluster.${baseDomain}
 baseDomain: ""
-
-# Add seccomp to pod security context
-podSecurityContext:
-  seccompProfile:
-    type: RuntimeDefault
-
-# Add seccomp to container security context
-securityContext:
-  seccompProfile:
-    type: RuntimeDefault


### PR DESCRIPTION
### What this PR does / why we need it

The change prevents the deployment of the operator

```
PodSecurityPolicy: unable to admit pod: [pod.metadata.annotations[seccomp.security.alpha.kubernetes.io/pod]: Forbidden: seccomp may not be set pod.metadata.annotations[container.seccomp.security.alpha.kubernetes.io/aws-resolver-rules-operator]
```

### Checklist

- [ ] Update changelog in CHANGELOG.md.
