### PR TITLE
Don't fail at start up if DNS server settings for resolver reconciler are missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add necessary values for PSS policy warnings.
 - Add new reconciler that creates hosted zones for reconciled clusters.
 
+### Changed
+
+- Don't fail at start up if DNS server settings for resolver rules reconciler are missing.
+
 ## [0.6.0] - 2023-05-05
 
 ### Fixed

--- a/pkg/resolver/dnsserver.go
+++ b/pkg/resolver/dnsserver.go
@@ -1,9 +1,5 @@
 package resolver
 
-import (
-	"github.com/pkg/errors"
-)
-
 type DNSServer struct {
 	// AWSAccountId is the AWS account id where the DNS server is deployed.
 	AWSAccountId string
@@ -18,22 +14,6 @@ type DNSServer struct {
 }
 
 func NewDNSServer(awsAccountId, iamExternalId, awsRegion, iamRoleToAssume, vpcId string) (DNSServer, error) {
-	if awsAccountId == "" {
-		return DNSServer{}, errors.New("AWS Account id can't be empty")
-	}
-	if iamExternalId == "" {
-		return DNSServer{}, errors.New("IAM External id can't be empty")
-	}
-	if awsRegion == "" {
-		return DNSServer{}, errors.New("AWS Region can't be empty")
-	}
-	if iamRoleToAssume == "" {
-		return DNSServer{}, errors.New("AWS IAM role can't be empty")
-	}
-	if vpcId == "" {
-		return DNSServer{}, errors.New("AWS VPC id can't be empty")
-	}
-
 	return DNSServer{
 		AWSAccountId:    awsAccountId,
 		IAMExternalId:   iamExternalId,


### PR DESCRIPTION
### What this PR does / why we need it
When reconciling clusters using private dns mode, we need to pass settings to specify the DNS server which we want to use when associating resolver rules. The operator fails to start if those settings are not passed, but this is only used for private clusters using private dns mode. So I'm removing the settings check and let the operator fail only if we reconcile clusters using private dns mode and the settings were not provided.

### Checklist

- [X] Update changelog in CHANGELOG.md.
