### PR TITLE
List many hosted zones at once in one Route53 request and cache all returned zones, cache hosted zone ID on creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Cache hosted zone ID on creation
+
 ## [0.14.1] - 2024-01-26
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Cache hosted zone ID on creation
+- List many hosted zones at once in one Route53 request and cache all returned zones. This further reduces the number of Route53 requests and therefore avoids rate limit (throttling) errors.
 
 ## [0.14.1] - 2024-01-26
 

--- a/pkg/aws/route53.go
+++ b/pkg/aws/route53.go
@@ -96,6 +96,7 @@ func (r *Route53) CreateHostedZone(ctx context.Context, logger logr.Logger, dnsZ
 			return "", errors.WithStack(err)
 		}
 		hostedZoneId = *createdHostedZone.HostedZone.Id
+		r.zoneNameToIdCache.SetDefault(dnsZone.DnsName, hostedZoneId)
 	}
 
 	logger = logger.WithValues("hostedZoneId", hostedZoneId)

--- a/pkg/resolver/zoner.go
+++ b/pkg/resolver/zoner.go
@@ -26,7 +26,7 @@ type Zoner struct {
 func NewDnsZone(awsClients AWSClients, workloadClusterBaseDomain string) (Zoner, error) {
 	return Zoner{
 		awsClients:                awsClients,
-		awsClientCache:            gocache.New(300*time.Second, 60*time.Second),
+		awsClientCache:            gocache.New(15*time.Minute, 60*time.Second),
 		workloadClusterBaseDomain: workloadClusterBaseDomain,
 	}, nil
 }

--- a/tests/integration/localstack/route53client_test.go
+++ b/tests/integration/localstack/route53client_test.go
@@ -83,7 +83,7 @@ var _ = Describe("Route53 Resolver client", func() {
 						MaxItems: awssdk.String("1"),
 					})
 					Expect(err).NotTo(HaveOccurred())
-					Expect(len(hostedZoneResponse.HostedZones)).To(Equal(1))
+					Expect(hostedZoneResponse.HostedZones).To(HaveLen(1))
 				})
 			})
 		})


### PR DESCRIPTION
### What this PR does / why we need it

Towards https://github.com/giantswarm/giantswarm/issues/29610

Both changes should avoid making lots of Route53 requests and thereby hitting their rate limit

Plus minor Makefile fix to not re-download docker-compose every time.

### Checklist

- [x] Update changelog in CHANGELOG.md.
