### PR TITLE
Fix finding NS record of the DNS zone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix finding NS record of the DNS zone. This only happens in rare cases.
+
 ## [0.14.4] - 2024-01-31
 
 ### Changed

--- a/pkg/resolver/package.go
+++ b/pkg/resolver/package.go
@@ -44,7 +44,7 @@ type Route53Client interface {
 	CreateHostedZone(ctx context.Context, logger logr.Logger, dnsZone DnsZone) (string, error)
 	DeleteHostedZone(ctx context.Context, logger logr.Logger, zoneId string) error
 	GetHostedZoneIdByName(ctx context.Context, logger logr.Logger, zoneName string) (string, error)
-	GetHostedZoneNSRecords(ctx context.Context, logger logr.Logger, zoneId string) (*DNSRecord, error)
+	GetHostedZoneNSRecord(ctx context.Context, logger logr.Logger, zoneId string, zoneName string) (*DNSRecord, error)
 	AddDelegationToParentZone(ctx context.Context, logger logr.Logger, parentZoneId string, resourceRecord *DNSRecord) error
 	DeleteDelegationFromParentZone(ctx context.Context, logger logr.Logger, parentZoneId string, resourceRecord *DNSRecord) error
 	AddDnsRecordsToHostedZone(ctx context.Context, logger logr.Logger, hostedZoneId string, dnsRecords []DNSRecord) error

--- a/pkg/resolver/resolverfakes/fake_route53client.go
+++ b/pkg/resolver/resolverfakes/fake_route53client.go
@@ -108,18 +108,19 @@ type FakeRoute53Client struct {
 		result1 string
 		result2 error
 	}
-	GetHostedZoneNSRecordsStub        func(context.Context, logr.Logger, string) (*resolver.DNSRecord, error)
-	getHostedZoneNSRecordsMutex       sync.RWMutex
-	getHostedZoneNSRecordsArgsForCall []struct {
+	GetHostedZoneNSRecordStub        func(context.Context, logr.Logger, string, string) (*resolver.DNSRecord, error)
+	getHostedZoneNSRecordMutex       sync.RWMutex
+	getHostedZoneNSRecordArgsForCall []struct {
 		arg1 context.Context
 		arg2 logr.Logger
 		arg3 string
+		arg4 string
 	}
-	getHostedZoneNSRecordsReturns struct {
+	getHostedZoneNSRecordReturns struct {
 		result1 *resolver.DNSRecord
 		result2 error
 	}
-	getHostedZoneNSRecordsReturnsOnCall map[int]struct {
+	getHostedZoneNSRecordReturnsOnCall map[int]struct {
 		result1 *resolver.DNSRecord
 		result2 error
 	}
@@ -582,20 +583,21 @@ func (fake *FakeRoute53Client) GetHostedZoneIdByNameReturnsOnCall(i int, result1
 	}{result1, result2}
 }
 
-func (fake *FakeRoute53Client) GetHostedZoneNSRecords(arg1 context.Context, arg2 logr.Logger, arg3 string) (*resolver.DNSRecord, error) {
-	fake.getHostedZoneNSRecordsMutex.Lock()
-	ret, specificReturn := fake.getHostedZoneNSRecordsReturnsOnCall[len(fake.getHostedZoneNSRecordsArgsForCall)]
-	fake.getHostedZoneNSRecordsArgsForCall = append(fake.getHostedZoneNSRecordsArgsForCall, struct {
+func (fake *FakeRoute53Client) GetHostedZoneNSRecord(arg1 context.Context, arg2 logr.Logger, arg3 string, arg4 string) (*resolver.DNSRecord, error) {
+	fake.getHostedZoneNSRecordMutex.Lock()
+	ret, specificReturn := fake.getHostedZoneNSRecordReturnsOnCall[len(fake.getHostedZoneNSRecordArgsForCall)]
+	fake.getHostedZoneNSRecordArgsForCall = append(fake.getHostedZoneNSRecordArgsForCall, struct {
 		arg1 context.Context
 		arg2 logr.Logger
 		arg3 string
-	}{arg1, arg2, arg3})
-	stub := fake.GetHostedZoneNSRecordsStub
-	fakeReturns := fake.getHostedZoneNSRecordsReturns
-	fake.recordInvocation("GetHostedZoneNSRecords", []interface{}{arg1, arg2, arg3})
-	fake.getHostedZoneNSRecordsMutex.Unlock()
+		arg4 string
+	}{arg1, arg2, arg3, arg4})
+	stub := fake.GetHostedZoneNSRecordStub
+	fakeReturns := fake.getHostedZoneNSRecordReturns
+	fake.recordInvocation("GetHostedZoneNSRecord", []interface{}{arg1, arg2, arg3, arg4})
+	fake.getHostedZoneNSRecordMutex.Unlock()
 	if stub != nil {
-		return stub(arg1, arg2, arg3)
+		return stub(arg1, arg2, arg3, arg4)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -603,46 +605,46 @@ func (fake *FakeRoute53Client) GetHostedZoneNSRecords(arg1 context.Context, arg2
 	return fakeReturns.result1, fakeReturns.result2
 }
 
-func (fake *FakeRoute53Client) GetHostedZoneNSRecordsCallCount() int {
-	fake.getHostedZoneNSRecordsMutex.RLock()
-	defer fake.getHostedZoneNSRecordsMutex.RUnlock()
-	return len(fake.getHostedZoneNSRecordsArgsForCall)
+func (fake *FakeRoute53Client) GetHostedZoneNSRecordCallCount() int {
+	fake.getHostedZoneNSRecordMutex.RLock()
+	defer fake.getHostedZoneNSRecordMutex.RUnlock()
+	return len(fake.getHostedZoneNSRecordArgsForCall)
 }
 
-func (fake *FakeRoute53Client) GetHostedZoneNSRecordsCalls(stub func(context.Context, logr.Logger, string) (*resolver.DNSRecord, error)) {
-	fake.getHostedZoneNSRecordsMutex.Lock()
-	defer fake.getHostedZoneNSRecordsMutex.Unlock()
-	fake.GetHostedZoneNSRecordsStub = stub
+func (fake *FakeRoute53Client) GetHostedZoneNSRecordCalls(stub func(context.Context, logr.Logger, string, string) (*resolver.DNSRecord, error)) {
+	fake.getHostedZoneNSRecordMutex.Lock()
+	defer fake.getHostedZoneNSRecordMutex.Unlock()
+	fake.GetHostedZoneNSRecordStub = stub
 }
 
-func (fake *FakeRoute53Client) GetHostedZoneNSRecordsArgsForCall(i int) (context.Context, logr.Logger, string) {
-	fake.getHostedZoneNSRecordsMutex.RLock()
-	defer fake.getHostedZoneNSRecordsMutex.RUnlock()
-	argsForCall := fake.getHostedZoneNSRecordsArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+func (fake *FakeRoute53Client) GetHostedZoneNSRecordArgsForCall(i int) (context.Context, logr.Logger, string, string) {
+	fake.getHostedZoneNSRecordMutex.RLock()
+	defer fake.getHostedZoneNSRecordMutex.RUnlock()
+	argsForCall := fake.getHostedZoneNSRecordArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
 }
 
-func (fake *FakeRoute53Client) GetHostedZoneNSRecordsReturns(result1 *resolver.DNSRecord, result2 error) {
-	fake.getHostedZoneNSRecordsMutex.Lock()
-	defer fake.getHostedZoneNSRecordsMutex.Unlock()
-	fake.GetHostedZoneNSRecordsStub = nil
-	fake.getHostedZoneNSRecordsReturns = struct {
+func (fake *FakeRoute53Client) GetHostedZoneNSRecordReturns(result1 *resolver.DNSRecord, result2 error) {
+	fake.getHostedZoneNSRecordMutex.Lock()
+	defer fake.getHostedZoneNSRecordMutex.Unlock()
+	fake.GetHostedZoneNSRecordStub = nil
+	fake.getHostedZoneNSRecordReturns = struct {
 		result1 *resolver.DNSRecord
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *FakeRoute53Client) GetHostedZoneNSRecordsReturnsOnCall(i int, result1 *resolver.DNSRecord, result2 error) {
-	fake.getHostedZoneNSRecordsMutex.Lock()
-	defer fake.getHostedZoneNSRecordsMutex.Unlock()
-	fake.GetHostedZoneNSRecordsStub = nil
-	if fake.getHostedZoneNSRecordsReturnsOnCall == nil {
-		fake.getHostedZoneNSRecordsReturnsOnCall = make(map[int]struct {
+func (fake *FakeRoute53Client) GetHostedZoneNSRecordReturnsOnCall(i int, result1 *resolver.DNSRecord, result2 error) {
+	fake.getHostedZoneNSRecordMutex.Lock()
+	defer fake.getHostedZoneNSRecordMutex.Unlock()
+	fake.GetHostedZoneNSRecordStub = nil
+	if fake.getHostedZoneNSRecordReturnsOnCall == nil {
+		fake.getHostedZoneNSRecordReturnsOnCall = make(map[int]struct {
 			result1 *resolver.DNSRecord
 			result2 error
 		})
 	}
-	fake.getHostedZoneNSRecordsReturnsOnCall[i] = struct {
+	fake.getHostedZoneNSRecordReturnsOnCall[i] = struct {
 		result1 *resolver.DNSRecord
 		result2 error
 	}{result1, result2}
@@ -665,8 +667,8 @@ func (fake *FakeRoute53Client) Invocations() map[string][][]interface{} {
 	defer fake.deleteHostedZoneMutex.RUnlock()
 	fake.getHostedZoneIdByNameMutex.RLock()
 	defer fake.getHostedZoneIdByNameMutex.RUnlock()
-	fake.getHostedZoneNSRecordsMutex.RLock()
-	defer fake.getHostedZoneNSRecordsMutex.RUnlock()
+	fake.getHostedZoneNSRecordMutex.RLock()
+	defer fake.getHostedZoneNSRecordMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/pkg/resolver/zoner.go
+++ b/pkg/resolver/zoner.go
@@ -90,7 +90,7 @@ func (d *Zoner) CreateHostedZone(ctx context.Context, logger logr.Logger, cluste
 			return errors.WithStack(err)
 		}
 
-		nsRecord, err := route53Client.GetHostedZoneNSRecords(ctx, logger, hostedZoneId)
+		nsRecord, err := route53Client.GetHostedZoneNSRecord(ctx, logger, hostedZoneId, dnsZoneToCreate.DnsName)
 		if err != nil {
 			return errors.WithStack(err)
 		}
@@ -132,7 +132,7 @@ func (d *Zoner) DeleteHostedZone(ctx context.Context, logger logr.Logger, cluste
 			return errors.WithStack(err)
 		}
 
-		nsRecord, err := route53Client.GetHostedZoneNSRecords(ctx, logger, hostedZoneId)
+		nsRecord, err := route53Client.GetHostedZoneNSRecord(ctx, logger, hostedZoneId, hostedZoneName)
 		if err != nil {
 			return errors.WithStack(err)
 		}


### PR DESCRIPTION
### What this PR does / why we need it

Towards https://github.com/giantswarm/roadmap/issues/3221

Avoid assumptions. We had a case where the first record in the zone was an `A` record pointing to the ingress LB. Possibly from reuse of the same DNS zone (i.e. same cluster name) multiple times, but we're not sure why. Anyway, this meant that the AWS API didn't return the NS resource record set as first result.

Works on a test MC.

### Checklist

- [x] Update changelog in CHANGELOG.md.
