### PR TITLE
add-toleration-for-unitialized-nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Add toleration for `node.cluster.x-k8s.io/uninitialized` taint.
+- Add node affinity to prefer scheduling CAPI pods to control-plane nodes.
+
 ## [0.14.5] - 2024-02-07
 
 ### Fixed

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,8 @@ require (
 	sigs.k8s.io/controller-runtime v0.13.0
 )
 
+replace google.golang.org/protobuf v1.31.0 => google.golang.org/protobuf v1.33.0
+
 require (
 	cloud.google.com/go/compute v1.23.0 // indirect
 	cloud.google.com/go/compute/metadata v0.2.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -924,8 +924,8 @@ google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlba
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
-google.golang.org/protobuf v1.31.0 h1:g0LDEJHgrBl9N9r17Ru3sqWhkIx2NB67okBHPwC7hs8=
-google.golang.org/protobuf v1.31.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
+google.golang.org/protobuf v1.33.0 h1:uNO2rsAINq/JlFpSdYEKIZ0uKD/R9cpdv0T+yoGwGmI=
+google.golang.org/protobuf v1.33.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/helm/aws-resolver-rules-operator/templates/deployment.yaml
+++ b/helm/aws-resolver-rules-operator/templates/deployment.yaml
@@ -27,7 +27,7 @@ spec:
               matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
-            weight: 10    
+            weight: 10
       serviceAccountName: {{ include "resource.default.name"  . }}
       securityContext:
         runAsUser: {{ .Values.pod.user.id }}

--- a/helm/aws-resolver-rules-operator/templates/deployment.yaml
+++ b/helm/aws-resolver-rules-operator/templates/deployment.yaml
@@ -27,7 +27,7 @@ spec:
               matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
-                weight: 10
+            weight: 10    
       serviceAccountName: {{ include "resource.default.name"  . }}
       securityContext:
         runAsUser: {{ .Values.pod.user.id }}

--- a/helm/aws-resolver-rules-operator/templates/deployment.yaml
+++ b/helm/aws-resolver-rules-operator/templates/deployment.yaml
@@ -27,6 +27,7 @@ spec:
               matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
+                weight: 10
       serviceAccountName: {{ include "resource.default.name"  . }}
       securityContext:
         runAsUser: {{ .Values.pod.user.id }}

--- a/helm/aws-resolver-rules-operator/templates/deployment.yaml
+++ b/helm/aws-resolver-rules-operator/templates/deployment.yaml
@@ -20,6 +20,13 @@ spec:
       labels:
     {{- include "labels.selector" . | nindent 8 }}
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
       serviceAccountName: {{ include "resource.default.name"  . }}
       securityContext:
         runAsUser: {{ .Values.pod.user.id }}
@@ -65,6 +72,12 @@ spec:
             - mountPath: /home/.aws
               name: credentials
       terminationGracePeriodSeconds: 10
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/control-plane
+      - effect: NoSchedule
+        key: "node.cluster.x-k8s.io/uninitialized"
+        operator: "Exists"
       volumes:
         - name: credentials
           secret:


### PR DESCRIPTION
- Add toleration for `node.cluster.x-k8s.io/uninitialized` taint.
- Add node affinity to prefer scheduling CAPI pods to control-plane nodes.


https://github.com/giantswarm/giantswarm/issues/30433
