### PR TITLE
Rework acceptance tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,17 +52,30 @@ workflows:
             tags:
               only: /^v.*/
 
+      - hold:
+          type: approval
+          requires:
+            - unit-tests
+
       - integration-tests:
+          context: architect
+          requires:
+            - hold
           filters:
             tags:
               only: /^v.*/
 
       - acceptance-tests:
+          context: architect
+          requires:
+            - hold
           filters:
             tags:
               only: /^v.*/
 
       - architect/go-build:
+          requires:
+            - hold
           context: architect
           name: go-build
           binary: aws-resolver-rules-operator

--- a/tests/acceptance/acceptance_suite_test.go
+++ b/tests/acceptance/acceptance_suite_test.go
@@ -2,14 +2,24 @@ package acceptance_test
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
+	"os"
+	"strconv"
 	"testing"
+	"time"
 
+	awssdk "github.com/aws/aws-sdk-go/aws"
 	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/client-go/kubernetes/scheme"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/kubectl/pkg/scheme"
 	capa "sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
 	capi "sigs.k8s.io/cluster-api/api/v1beta1"
 	controllerruntime "sigs.k8s.io/controller-runtime"
@@ -17,6 +27,12 @@ import (
 
 	"github.com/aws-resolver-rules-operator/tests"
 	"github.com/aws-resolver-rules-operator/tests/acceptance/fixture"
+)
+
+const (
+	DefaultMaxLogLines     = 300
+	DefaultPollingInterval = 5 * time.Second
+	DefaultTimeout         = 3 * time.Minute
 )
 
 var (
@@ -28,12 +44,162 @@ var (
 	testFixture *fixture.Fixture
 )
 
+func LogCollectorFailHandler(message string, callerSkip ...int) {
+	getPodLogs()
+	Fail(message, callerSkip...)
+}
+
 func TestAcceptance(t *testing.T) {
-	RegisterFailHandler(Fail)
+	RegisterFailHandler(LogCollectorFailHandler)
 	RunSpecs(t, "Acceptance Suite")
 }
 
-var _ = BeforeSuite(func() {
+var _ = SynchronizedBeforeSuite(func() []byte {
+	setupEventuallyParameters()
+	k8sClient = setupKubeClient()
+
+	fixtureConfig := getFixtureConfig()
+	testFixture = fixture.NewFixture(k8sClient, fixtureConfig)
+
+	DeferCleanup(func() {
+		Expect(testFixture.Teardown()).To(Succeed())
+	})
+	err := testFixture.Setup()
+	Expect(err).NotTo(HaveOccurred())
+
+	data := fixture.Data{
+		Config:  fixtureConfig,
+		Network: testFixture.Network,
+	}
+	encoded, err := json.Marshal(data)
+	Expect(err).NotTo(HaveOccurred())
+
+	return encoded
+}, func(jsonData []byte) {
+	data := fixture.Data{}
+	err := json.Unmarshal(jsonData, &data)
+	Expect(err).NotTo(HaveOccurred())
+
+	setupEventuallyParameters()
+	k8sClient = setupKubeClient()
+
+	testFixture = fixture.LoadFixture(k8sClient, data)
+})
+
+var _ = BeforeEach(func() {
+	namespace = uuid.New().String()
+	namespaceObj = &corev1.Namespace{}
+	namespaceObj.Name = namespace
+	Expect(k8sClient.Create(context.Background(), namespaceObj)).To(Succeed())
+})
+
+var _ = AfterEach(func() {
+	Expect(k8sClient.Delete(context.Background(), namespaceObj)).To(Succeed())
+})
+
+func getDurationFromEnvVar(env string, defaultDuration time.Duration) time.Duration {
+	stringDuration := os.Getenv(env)
+	if stringDuration == "" {
+		return defaultDuration
+	}
+
+	duration, err := time.ParseDuration(stringDuration)
+	Expect(err).NotTo(HaveOccurred())
+
+	return duration
+}
+
+func getMaxLogLines() int64 {
+	maxLogLines := os.Getenv("MAX_LOG_LINES")
+	if maxLogLines == "" {
+		return DefaultMaxLogLines
+	}
+
+	maxLogLinesInt, err := strconv.Atoi(maxLogLines)
+	Expect(err).NotTo(HaveOccurred())
+
+	return int64(maxLogLinesInt)
+}
+
+func getPodLogs() {
+	kubeConfigPath := tests.GetEnvOrSkip("KUBECONFIG")
+	maxLogLines := getMaxLogLines()
+	config, err := clientcmd.BuildConfigFromFlags("", kubeConfigPath)
+	if err != nil {
+		fmt.Fprintf(GinkgoWriter, "Failed to build client config: %v", err)
+		return
+	}
+
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		fmt.Fprintf(GinkgoWriter, "Failed to build client: %v", err)
+		return
+	}
+
+	ctx := context.Background()
+	podsClient := clientset.CoreV1().Pods("giantswarm")
+	pods, err := podsClient.List(ctx, metav1.ListOptions{
+		LabelSelector: "app.kubernetes.io/name=aws-resolver-rules-operator",
+	})
+	if err != nil {
+		fmt.Fprintf(GinkgoWriter, "Failed to list pods: %v", err)
+		return
+	}
+
+	if len(pods.Items) == 0 {
+		fmt.Fprintf(GinkgoWriter, "No pods found: %v", err)
+		return
+	}
+	pod := pods.Items[0]
+
+	logOptions := corev1.PodLogOptions{TailLines: awssdk.Int64(maxLogLines)}
+	req := podsClient.GetLogs(pod.Name, &logOptions)
+	logStream, err := req.Stream(context.Background())
+	if err != nil {
+		fmt.Fprintf(GinkgoWriter, "Failed to get log stream: %v", err)
+		return
+	}
+	defer logStream.Close()
+
+	logBytes, err := io.ReadAll(logStream)
+	if err != nil {
+		fmt.Fprintf(GinkgoWriter, "Failed to read logs: %v", err)
+		return
+	}
+
+	fmt.Fprintf(GinkgoWriter,
+		"\n\n---------------- Last %d log lines for %q pod ----------------\n%s\n--------------------------------\n\n",
+		maxLogLines,
+		pod.Name,
+		string(logBytes))
+}
+
+func getFixtureConfig() fixture.Config {
+	awsAccount := tests.GetEnvOrSkip("MC_AWS_ACCOUNT")
+	iamRoleID := tests.GetEnvOrSkip("AWS_IAM_ROLE_ID")
+	awsRegion := tests.GetEnvOrSkip("AWS_REGION")
+	managementClusterName := tests.GetEnvOrSkip("MANAGEMENT_CLUSTER_NAME")
+	managementClusterNamespace := tests.GetEnvOrSkip("MANAGEMENT_CLUSTER_NAMESPACE")
+	roleARN := fmt.Sprintf("arn:aws:iam::%s:role/%s", awsAccount, iamRoleID)
+
+	return fixture.Config{
+		AWSAccount:                 awsAccount,
+		AWSIAMRoleARN:              roleARN,
+		AWSRegion:                  awsRegion,
+		ManagementClusterName:      managementClusterName,
+		ManagementClusterNamespace: managementClusterNamespace,
+	}
+}
+
+func setupEventuallyParameters() {
+	pollingInterval := getDurationFromEnvVar("EVENTUALLY_POLLING_INTERVAL", DefaultPollingInterval)
+	timeout := getDurationFromEnvVar("EVENTUALLY_TIMEOUT", DefaultTimeout)
+
+	SetDefaultEventuallyPollingInterval(pollingInterval)
+	SetDefaultEventuallyTimeout(timeout)
+}
+
+func setupKubeClient() client.Client {
 	tests.GetEnvOrSkip("KUBECONFIG")
 
 	config, err := controllerruntime.GetConfig()
@@ -48,30 +214,5 @@ var _ = BeforeSuite(func() {
 	k8sClient, err = client.New(config, client.Options{Scheme: scheme.Scheme})
 	Expect(err).NotTo(HaveOccurred())
 
-	awsAccount := tests.GetEnvOrSkip("MC_AWS_ACCOUNT")
-	iamRoleID := tests.GetEnvOrSkip("AWS_IAM_ROLE_ID")
-	awsRegion := tests.GetEnvOrSkip("AWS_REGION")
-	managementClusterName := tests.GetEnvOrSkip("MANAGEMENT_CLUSTER_NAME")
-	managementClusterNamespace := tests.GetEnvOrSkip("MANAGEMENT_CLUSTER_NAMESPACE")
-	roleARN := fmt.Sprintf("arn:aws:iam::%s:role/%s", awsAccount, iamRoleID)
-
-	fixtureConfig := fixture.Config{
-		AWSAccount:                 awsAccount,
-		AWSIAMRoleARN:              roleARN,
-		AWSRegion:                  awsRegion,
-		ManagementClusterName:      managementClusterName,
-		ManagementClusterNamespace: managementClusterNamespace,
-	}
-	testFixture = fixture.NewFixture(k8sClient, fixtureConfig)
-})
-
-var _ = BeforeEach(func() {
-	namespace = uuid.New().String()
-	namespaceObj = &corev1.Namespace{}
-	namespaceObj.Name = namespace
-	Expect(k8sClient.Create(context.Background(), namespaceObj)).To(Succeed())
-})
-
-var _ = AfterEach(func() {
-	Expect(k8sClient.Delete(context.Background(), namespaceObj)).To(Succeed())
-})
+	return k8sClient
+}

--- a/tests/acceptance/fixture/aws.go
+++ b/tests/acceptance/fixture/aws.go
@@ -1,6 +1,7 @@
 package fixture
 
 import (
+	"context"
 	"fmt"
 
 	awssdk "github.com/aws/aws-sdk-go/aws"
@@ -13,6 +14,62 @@ const (
 	ManagementClusterCIDR = "172.64.0.0"
 	WorkloadClusterCIDR   = "172.96.0.0"
 )
+
+func DetachTransitGateway(ec2Client *ec2.EC2, gatewayID, vpcID string) error {
+	if gatewayID == "" || vpcID == "" {
+		return nil
+	}
+
+	describeTGWattachmentInput := &ec2.DescribeTransitGatewayVpcAttachmentsInput{
+		Filters: []*ec2.Filter{
+			{
+				Name:   awssdk.String("transit-gateway-id"),
+				Values: awssdk.StringSlice([]string{gatewayID}),
+			},
+			{
+				Name:   awssdk.String("vpc-id"),
+				Values: awssdk.StringSlice([]string{vpcID}),
+			},
+		},
+	}
+	attachments, err := ec2Client.DescribeTransitGatewayVpcAttachments(describeTGWattachmentInput)
+	if err != nil {
+		return err
+	}
+
+	for _, attachment := range attachments.TransitGatewayVpcAttachments {
+		_, err = ec2Client.DeleteTransitGatewayVpcAttachmentWithContext(context.Background(), &ec2.DeleteTransitGatewayVpcAttachmentInput{
+			TransitGatewayAttachmentId: attachment.TransitGatewayAttachmentId,
+		})
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func DeleteTransitGateway(ec2Client *ec2.EC2, gatewayID string) error {
+	if gatewayID == "" {
+		return nil
+	}
+
+	_, err := ec2Client.DeleteTransitGateway(&ec2.DeleteTransitGatewayInput{
+		TransitGatewayId: awssdk.String(gatewayID),
+	})
+	return err
+}
+
+func DeletePrefixList(ec2Client *ec2.EC2, prefixListID string) error {
+	if prefixListID == "" {
+		return nil
+	}
+
+	_, err := ec2Client.DeleteManagedPrefixList(&ec2.DeleteManagedPrefixListInput{
+		PrefixListId: awssdk.String(prefixListID),
+	})
+	return err
+}
 
 func DisassociateRouteTable(ec2Client *ec2.EC2, associationID string) error {
 	if associationID == "" {

--- a/tests/acceptance/fixture/fixture.go
+++ b/tests/acceptance/fixture/fixture.go
@@ -3,16 +3,19 @@ package fixture
 import (
 	"context"
 	"fmt"
+	"time"
 
 	awssdk "github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/ram"
+	"github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	capa "sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
 	capi "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -20,12 +23,19 @@ import (
 	gsannotations "github.com/giantswarm/k8smetadata/pkg/annotation"
 
 	"github.com/aws-resolver-rules-operator/controllers"
+	"github.com/aws-resolver-rules-operator/pkg/aws"
+	"github.com/aws-resolver-rules-operator/pkg/util/annotations"
 )
 
 const (
 	ClusterVCPCIDR    = "172.64.0.0/16"
 	ClusterSubnetCIDR = "172.64.0.0/20"
 )
+
+type Data struct {
+	Config  Config  `json:"config"`
+	Network Network `json:"network"`
+}
 
 func NewFixture(k8sClient client.Client, config Config) *Fixture {
 	session, err := session.NewSession(&awssdk.Config{
@@ -52,11 +62,12 @@ func NewFixture(k8sClient client.Client, config Config) *Fixture {
 	}
 }
 
-type Network struct {
-	AssociationID string
-	RouteTableID  string
-	SubnetID      string
-	VpcID         string
+func LoadFixture(k8sClient client.Client, data Data) *Fixture {
+	f := NewFixture(k8sClient, data.Config)
+	f.Network = data.Network
+	f.ManagementCluster = f.loadCluster(data.Network)
+
+	return f
 }
 
 type Cluster struct {
@@ -65,12 +76,19 @@ type Cluster struct {
 	ClusterRoleIdentity *capa.AWSClusterRoleIdentity
 }
 
+type Network struct {
+	AssociationID string `json:"associationID"`
+	RouteTableID  string `json:"routeTableID"`
+	SubnetID      string `json:"subnetID"`
+	VpcID         string `json:"vpcID"`
+}
+
 type Config struct {
-	AWSAccount                 string
-	AWSIAMRoleARN              string
-	AWSRegion                  string
-	ManagementClusterName      string
-	ManagementClusterNamespace string
+	AWSAccount                 string `json:"awsAccount"`
+	AWSIAMRoleARN              string `json:"awsIAMRoleARN"`
+	AWSRegion                  string `json:"awsRegion"`
+	ManagementClusterName      string `json:"managementClusterName"`
+	ManagementClusterNamespace string `json:"managementClusterNamespace"`
 }
 
 type Fixture struct {
@@ -78,10 +96,10 @@ type Fixture struct {
 	EC2Client *ec2.EC2
 	RamClient *ram.RAM
 
-	Network           Network
 	ManagementCluster Cluster
 
-	config Config
+	Network Network
+	config  Config
 }
 
 func (f *Fixture) Setup() error {
@@ -92,20 +110,34 @@ func (f *Fixture) Setup() error {
 }
 
 func (f *Fixture) Teardown() error {
-	f.deleteCluster()
-
-	err := DeleteKubernetesObject(f.K8sClient, f.ManagementCluster.AWSCluster)
+	actualCluster := &capa.AWSCluster{}
+	err := f.K8sClient.Get(context.Background(), client.ObjectKeyFromObject(f.ManagementCluster.Cluster), actualCluster)
 	Expect(err).NotTo(HaveOccurred())
 
-	Eventually(func() error {
-		return f.K8sClient.Get(context.Background(),
-			client.ObjectKeyFromObject(f.ManagementCluster.AWSCluster),
-			&capa.AWSCluster{},
-		)
-	}).ShouldNot(Succeed())
+	err = f.deleteCluster()
+	if err != nil {
+		defer ginkgo.Fail(fmt.Sprintf("failed to delete cluster: %v", err))
+	}
 
 	err = DeleteKubernetesObject(f.K8sClient, f.ManagementCluster.ClusterRoleIdentity)
 	Expect(err).NotTo(HaveOccurred())
+
+	transitGatewayAnnotation := annotations.GetNetworkTopologyTransitGateway(actualCluster)
+	prefixListAnnotation := annotations.GetNetworkTopologyPrefixList(actualCluster)
+
+	gatewayID := getARNID(transitGatewayAnnotation)
+	prefixListID := getARNID(prefixListAnnotation)
+
+	err = DeletePrefixList(f.EC2Client, prefixListID)
+	Expect(err).NotTo(HaveOccurred())
+
+	err = DetachTransitGateway(f.EC2Client, gatewayID, f.Network.VpcID)
+	Expect(err).NotTo(HaveOccurred())
+
+	Eventually(func() error {
+		err := DeleteTransitGateway(f.EC2Client, gatewayID)
+		return err
+	}).Should(Succeed())
 
 	err = DisassociateRouteTable(f.EC2Client, f.Network.AssociationID)
 	Expect(err).NotTo(HaveOccurred())
@@ -186,13 +218,13 @@ func (f *Fixture) createCluster(network Network) Cluster {
 	cluster := &capi.Cluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      f.config.ManagementClusterName,
-			Namespace: "test",
+			Namespace: f.config.ManagementClusterNamespace,
 		},
 		Spec: capi.ClusterSpec{
 			InfrastructureRef: &corev1.ObjectReference{
 				APIVersion: capa.GroupVersion.String(),
 				Kind:       "AWSCluster",
-				Namespace:  "test",
+				Namespace:  f.config.ManagementClusterNamespace,
 				Name:       f.config.ManagementClusterName,
 			},
 		},
@@ -204,7 +236,7 @@ func (f *Fixture) createCluster(network Network) Cluster {
 	awsCluster := &capa.AWSCluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      f.config.ManagementClusterName,
-			Namespace: "test",
+			Namespace: f.config.ManagementClusterNamespace,
 			Annotations: map[string]string{
 				gsannotations.NetworkTopologyModeAnnotation: gsannotations.NetworkTopologyModeGiantSwarmManaged,
 			},
@@ -242,22 +274,66 @@ func (f *Fixture) createCluster(network Network) Cluster {
 	}
 }
 
-func (f *Fixture) deleteCluster() {
-	cluster := f.ManagementCluster.Cluster
-	err := DeleteKubernetesObject(f.K8sClient, cluster)
+func (f *Fixture) loadCluster(network Network) Cluster {
+	ctx := context.Background()
+
+	clusterRoleIdentity := &capa.AWSClusterRoleIdentity{}
+	err := f.K8sClient.Get(ctx, types.NamespacedName{
+		Name: f.config.ManagementClusterName,
+	}, clusterRoleIdentity)
 	Expect(err).NotTo(HaveOccurred())
 
-	if cluster == nil {
-		return
+	cluster := &capi.Cluster{}
+	err = f.K8sClient.Get(ctx, types.NamespacedName{
+		Name:      f.config.ManagementClusterName,
+		Namespace: f.config.ManagementClusterNamespace,
+	}, cluster)
+	Expect(err).NotTo(HaveOccurred())
+
+	awsCluster := &capa.AWSCluster{}
+	err = f.K8sClient.Get(ctx, types.NamespacedName{
+		Name:      f.config.ManagementClusterName,
+		Namespace: f.config.ManagementClusterNamespace,
+	}, awsCluster)
+	Expect(err).NotTo(HaveOccurred())
+
+	return Cluster{
+		Cluster:             cluster,
+		AWSCluster:          awsCluster,
+		ClusterRoleIdentity: clusterRoleIdentity,
 	}
-	Eventually(func() []string {
-		actualCluster := &capi.Cluster{}
-		err := f.K8sClient.Get(context.Background(), client.ObjectKeyFromObject(cluster), actualCluster)
-		if k8serrors.IsNotFound(err) {
-			return []string{}
+}
+
+func (f *Fixture) deleteCluster() error {
+	err := DeleteKubernetesObject(f.K8sClient, f.ManagementCluster.Cluster)
+	Expect(err).NotTo(HaveOccurred())
+
+	awsCluster := f.ManagementCluster.AWSCluster
+	err = DeleteKubernetesObject(f.K8sClient, awsCluster)
+	Expect(err).NotTo(HaveOccurred())
+
+	if awsCluster == nil {
+		return nil
+	}
+
+	timeout := time.After(3 * time.Minute)
+	tick := time.NewTicker(5 * time.Second)
+
+	for {
+		select {
+		case <-timeout:
+			return fmt.Errorf("timeout waiting for cluster deletion")
+		case <-tick.C:
+			actualCluster := &capi.Cluster{}
+			err := f.K8sClient.Get(context.Background(), client.ObjectKeyFromObject(awsCluster), actualCluster)
+			if k8serrors.IsNotFound(err) {
+				return nil
+			}
+			if err != nil {
+				return err
+			}
 		}
-		return actualCluster.Finalizers
-	}).ShouldNot(ContainElement(controllers.FinalizerManagementCluster))
+	}
 }
 
 func getAvailabilityZone(region string) string {
@@ -282,4 +358,14 @@ func generateTagSpecifications(name string) []*ec2.TagSpecification {
 	tagSpecifications := make([]*ec2.TagSpecification, 0)
 	tagSpecifications = append(tagSpecifications, tagSpec)
 	return tagSpecifications
+}
+
+func getARNID(arn string) string {
+	if arn == "" {
+		return ""
+	}
+
+	resourceID, err := aws.GetARNResourceID(arn)
+	Expect(err).NotTo(HaveOccurred())
+	return resourceID
 }

--- a/tests/acceptance/transit_gateways_test.go
+++ b/tests/acceptance/transit_gateways_test.go
@@ -3,7 +3,6 @@ package acceptance_test
 import (
 	"context"
 	"fmt"
-	"time"
 
 	awssdk "github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
@@ -16,47 +15,54 @@ import (
 	gsannotation "github.com/giantswarm/k8smetadata/pkg/annotation"
 
 	"github.com/aws-resolver-rules-operator/pkg/aws"
-	"github.com/aws-resolver-rules-operator/pkg/util/annotations"
 )
 
 var _ = Describe("Transit Gateways", func() {
-	var ctx context.Context
+	var (
+		ctx context.Context
+
+		transitGatewayID string
+		prefixListID     string
+	)
+
+	getClusterAnnotations := func(g Gomega) map[string]string {
+		actualCluster := &capa.AWSCluster{}
+		nsName := client.ObjectKeyFromObject(testFixture.ManagementCluster.Cluster)
+		err := k8sClient.Get(ctx, nsName, actualCluster)
+		g.Expect(err).NotTo(HaveOccurred())
+
+		return actualCluster.Annotations
+	}
 
 	BeforeEach(func() {
 		ctx = context.Background()
-		SetDefaultEventuallyPollingInterval(time.Second)
-		SetDefaultEventuallyTimeout(5 * time.Minute)
 
-		DeferCleanup(func() {
-			Expect(testFixture.Teardown()).To(Succeed())
-		})
-		err := testFixture.Setup()
+		annotations := map[string]string{}
+		Eventually(func(g Gomega) map[string]string {
+			annotations = getClusterAnnotations(g)
+			return annotations
+		}).Should(And(
+			HaveKey(gsannotation.NetworkTopologyTransitGatewayIDAnnotation),
+			HaveKey(gsannotation.NetworkTopologyPrefixListIDAnnotation)),
+		)
+
+		var err error
+		transitGatewayID, err = aws.GetARNResourceID(annotations[gsannotation.NetworkTopologyTransitGatewayIDAnnotation])
+		Expect(err).NotTo(HaveOccurred())
+
+		prefixListID, err = aws.GetARNResourceID(annotations[gsannotation.NetworkTopologyPrefixListIDAnnotation])
 		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("creates the transit gateway", func() {
-		By("creating the transit gateway")
-		actualCluster := &capa.AWSCluster{}
-
-		getClusterAnnotations := func(g Gomega) map[string]string {
-			nsName := client.ObjectKeyFromObject(testFixture.ManagementCluster.Cluster)
-			err := k8sClient.Get(ctx, nsName, actualCluster)
-			g.Expect(err).NotTo(HaveOccurred())
-
-			return actualCluster.Annotations
-		}
-		Eventually(getClusterAnnotations).Should(HaveKey(gsannotation.NetworkTopologyTransitGatewayIDAnnotation))
-
-		transitGatewayID, err := aws.GetARNResourceID(annotations.GetNetworkTopologyTransitGateway(actualCluster))
-		Expect(err).NotTo(HaveOccurred())
-
 		output, err := testFixture.EC2Client.DescribeTransitGateways(&ec2.DescribeTransitGatewaysInput{
 			TransitGatewayIds: []*string{awssdk.String(transitGatewayID)},
 		})
 		Expect(err).NotTo(HaveOccurred())
 		Expect(output.TransitGateways).To(HaveLen(1))
+	})
 
-		By("attaching the transit gateway")
+	It("attaches the transit gateway", func() {
 		getTGWAttachments := func() []*ec2.TransitGatewayVpcAttachment {
 			describeTGWattachmentInput := &ec2.DescribeTransitGatewayVpcAttachmentsInput{
 				Filters: []*ec2.Filter{
@@ -77,12 +83,10 @@ var _ = Describe("Transit Gateways", func() {
 		Eventually(getTGWAttachments).Should(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
 			"State": PointTo(Equal("available")),
 		}))))
+	})
 
-		By("creating the prefix list")
+	It("creates the prefix list", func() {
 		Eventually(getClusterAnnotations).Should(HaveKey(gsannotation.NetworkTopologyPrefixListIDAnnotation))
-
-		prefixListID, err := aws.GetARNResourceID(annotations.GetNetworkTopologyPrefixList(actualCluster))
-		Expect(err).NotTo(HaveOccurred())
 
 		managementAWSCluster := testFixture.ManagementCluster.AWSCluster
 		prefixListDescription := fmt.Sprintf("CIDR block for cluster %s", managementAWSCluster.Name)
@@ -97,8 +101,10 @@ var _ = Describe("Transit Gateways", func() {
 			"Cidr":        PointTo(Equal(managementAWSCluster.Spec.NetworkSpec.VPC.CidrBlock)),
 			"Description": PointTo(Equal(prefixListDescription)),
 		}))))
+	})
 
-		By("creating a route in explicitly attached route tables")
+	It("creates a route in explicitly attached route tables", func() {
+		managementAWSCluster := testFixture.ManagementCluster.AWSCluster
 		getRouteTables := func() []*ec2.RouteTable {
 			subnets := []*string{}
 			for _, s := range managementAWSCluster.Spec.NetworkSpec.Subnets {


### PR DESCRIPTION
- Require approval for running integration and acceptance tests. This will prevent automatic PRs from renovate and architect to trigger them.
- Add fail handler that prints pod logs. The amount of log lines is configurable with an env var.
- Add env vars to control Eventually polling interval and timeout
- Run tests in parallel. This requires using SynchronizedBeforeEach to set up MC only once.
- Use random name for MC. The name is generated in the Makefile before deploying and running the tests.
- Improve cleanup logic. The test cleanup will be performed even if deletion fails. This means that even if an introduced change breaks the deletion loop, no manual cleanup will be necessary.

### What this PR does / why we need it
Towards https://github.com/giantswarm/giantswarm/issues/30900

### Checklist

- [ ] Update changelog in CHANGELOG.md.
_These changes don't really belong in the CHANGELOG I think. They change nothing about the operator from a user's point of view and I won't create a release for this  as there's no point. Happy to discuss if you think otherwise._
