### PR TITLE
Clarify dependency of aws-vpc-operator and aws-resolver-rules-operator regarding paused cluster objects

### DIFF
--- a/controllers/unpause.go
+++ b/controllers/unpause.go
@@ -44,8 +44,9 @@ func NewUnpauseReconciler(awsClusterClient AWSClusterClient) *UnpauseReconciler 
 }
 
 // Reconcile will unpause the reconciled cluster when certain conditions are marked as true.
-// It will unpause the Cluster and AWSCluster when VPC and Subnet conditions are marked as ready.
-// It also requires the ResolverRules condition to be ready if using the private dns mode.
+// It will unpause the Cluster and AWSCluster when VPC and Subnet conditions are marked as ready
+// (see aws-vpc-operator), *and* if using the private dns mode, it also requires the
+// ResolverRules condition to be ready.
 func (r *UnpauseReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
 	logger.Info("Reconciling")


### PR DESCRIPTION
### What this PR does / why we need it

cluster-aws sets the paused annotation for private clusters so that aws-vpc-operator can create a custom VPC+networking, and then it's aws-resolver-rules-operator removing the paused annotation 🤯. I want to have this tiny documentation at least in one spot before someone else researches this mystery.

### Checklist

- [ ] Update changelog in CHANGELOG.md.
