### PR TITLE
Dynamically calculate CAPI and CAPA versions to install CRDs from the right paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Dynamically calculate CAPI and CAPA versions from go cache, so that we use the right path when installing the CRDs during tests.
+
 ## [0.17.0] - 2024-09-30
 
 ### Changed

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.20.4
 	go.uber.org/zap v1.27.0
+	golang.org/x/tools v0.24.0
 	k8s.io/api v0.31.0
 	k8s.io/apimachinery v0.31.0
 	k8s.io/client-go v0.31.0
@@ -75,7 +76,6 @@ require (
 	golang.org/x/term v0.23.0 // indirect
 	golang.org/x/text v0.17.0 // indirect
 	golang.org/x/time v0.5.0 // indirect
-	golang.org/x/tools v0.24.0 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.4.0 // indirect
 	google.golang.org/protobuf v1.34.2 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect


### PR DESCRIPTION
### What this PR does / why we need it

When renovate creates PR to bump CAPI or CAPA, our unit tests fail because the path used to install the CRDs is different (it contains the version in the path). I added a couple of lines to calculate it dynamically.

### Checklist

- [X] Update changelog in CHANGELOG.md.
