### PR TITLE
Add tags to VPC created for acceptance tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Dynamically calculate CAPI and CAPA versions from go cache, so that we use the right path when installing the CRDs during tests.
+- Add tags to VPC created for acceptance tests.
 
 ### Fixed
 

--- a/tests/acceptance/fixture/fixture.go
+++ b/tests/acceptance/fixture/fixture.go
@@ -157,6 +157,17 @@ func (f *Fixture) Teardown() error {
 func (f *Fixture) createNetwork() Network {
 	createVpcOutput, err := f.EC2Client.CreateVpc(&ec2.CreateVpcInput{
 		CidrBlock: awssdk.String(ClusterVCPCIDR),
+		TagSpecifications: []*ec2.TagSpecification{
+			{
+				ResourceType: awssdk.String(ec2.ResourceTypeVpc),
+				Tags: []*ec2.Tag{
+					{
+						Key:   awssdk.String("aws-resolver-rules-operator.giantswarm.io/tests"),
+						Value: awssdk.String("acceptance"),
+					},
+				},
+			},
+		},
 	})
 	Expect(err).NotTo(HaveOccurred())
 


### PR DESCRIPTION
### What this PR does / why we need it

I feel like when acceptance tests fail, sometimes they don't clean up after themselves and it's leaking AWS resources like VPCs, but without tags it's hard to tell.

### Checklist

- [X] Update changelog in CHANGELOG.md.
