### PR TITLE
Add crossplane config controller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add crossplane controller to create crossplane provider cluster config.
+
 ## [0.18.0] - 2025-06-16
 
 ### Added
 
 - Add controller to create node pool bootstrap data on S3.
-- Add crossplane controller to create crossplane provider config.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add controller to create node pool bootstrap data on S3.
+- Add crossplane controller to create crossplane provider config.
 
 ### Changed
 

--- a/controllers/controllers_suite_test.go
+++ b/controllers/controllers_suite_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"go/build"
 	"math/rand"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -34,6 +35,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kubectl/pkg/scheme"
 	capa "sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
+	eks "sigs.k8s.io/cluster-api-provider-aws/v2/controlplane/eks/api/v1beta2"
 	capi "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
@@ -81,10 +83,14 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 
 	By("bootstrapping test environment")
+	ex, err := os.Executable()
+	Expect(err).NotTo(HaveOccurred())
+	crdPath := filepath.Join(filepath.Dir(ex), "..", "tests", "testdata", "crds")
 	testEnv = &envtest.Environment{
 		CRDDirectoryPaths: []string{
 			filepath.Join(build.Default.GOPATH, "pkg", "mod", "sigs.k8s.io", fmt.Sprintf("cluster-api@%s", capiModule[0].Module.Version), "config", "crd", "bases"),
 			filepath.Join(build.Default.GOPATH, "pkg", "mod", "sigs.k8s.io", "cluster-api-provider-aws", fmt.Sprintf("v2@%s", capaModule[0].Module.Version), "config", "crd", "bases"),
+			crdPath,
 		},
 		ErrorIfCRDPathMissing: true,
 	}
@@ -98,7 +104,9 @@ var _ = BeforeSuite(func() {
 
 	err = capi.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
-	// +kubebuilder:scaffold:scheme
+
+	err = eks.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
 
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
 	Expect(err).NotTo(HaveOccurred())
@@ -194,21 +202,6 @@ func createRandomClusterWithIdentity(annotationsKeyValues ...string) (*capa.AWSC
 	return identity, awsCluster
 }
 
-func newRoleIdentity() *capa.AWSClusterRoleIdentity {
-	name := uuid.NewString()
-	return &capa.AWSClusterRoleIdentity{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
-		},
-		Spec: capa.AWSClusterRoleIdentitySpec{
-			AWSRoleSpec: capa.AWSRoleSpec{
-				RoleArn: uuid.NewString(),
-			},
-		},
-	}
-}
-
 func newSubnetSpec(id, availabilityZone string, transitGatewayTagged bool) capa.SubnetSpec {
 	subnet := capa.SubnetSpec{
 		ID:               id,
@@ -223,4 +216,173 @@ func newSubnetSpec(id, availabilityZone string, transitGatewayTagged bool) capa.
 	}
 
 	return subnet
+}
+
+func newCapiCluster(name string, annotationsKeyValues ...string) *capi.Cluster {
+	if len(annotationsKeyValues)%2 != 0 {
+		Fail("wrong number of arguments for newCluster. Expected even number of arguments for annotation key/value pairs")
+	}
+
+	annotations := map[string]string{}
+	for i := 0; i < len(annotationsKeyValues); i += 2 {
+		annotations[annotationsKeyValues[i]] = annotationsKeyValues[i+1]
+	}
+
+	awsCluster := &capi.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Namespace:   namespace,
+			Annotations: annotations,
+		},
+	}
+
+	return awsCluster
+}
+
+func newCapaCluster(name string, annotationsKeyValues ...string) *capa.AWSCluster {
+	if len(annotationsKeyValues)%2 != 0 {
+		Fail("wrong number of arguments for newCluster. Expected even number of arguments for annotation key/value pairs")
+	}
+
+	annotations := map[string]string{}
+	for i := 0; i < len(annotationsKeyValues); i += 2 {
+		annotations[annotationsKeyValues[i]] = annotationsKeyValues[i+1]
+	}
+
+	awsCluster := &capa.AWSCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Namespace:   namespace,
+			Annotations: annotations,
+		},
+		Spec: capa.AWSClusterSpec{
+			Region: "the-region",
+			NetworkSpec: capa.NetworkSpec{
+				VPC: capa.VPCSpec{
+					ID:        "vpc-1",
+					CidrBlock: fmt.Sprintf("10.%d.0.0/24", rand.Intn(255)),
+				},
+				Subnets: capa.Subnets{
+					{
+						ID:       "sub-1",
+						IsPublic: false,
+					},
+				},
+			},
+		},
+	}
+
+	return awsCluster
+}
+
+func newEksCluster(name string, annotationsKeyValues ...string) *eks.AWSManagedControlPlane {
+	if len(annotationsKeyValues)%2 != 0 {
+		Fail("wrong number of arguments for newCluster. Expected even number of arguments for annotation key/value pairs")
+	}
+
+	annotations := map[string]string{}
+	for i := 0; i < len(annotationsKeyValues); i += 2 {
+		annotations[annotationsKeyValues[i]] = annotationsKeyValues[i+1]
+	}
+
+	eksCluster := &eks.AWSManagedControlPlane{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Namespace:   namespace,
+			Annotations: annotations,
+		},
+		Spec: eks.AWSManagedControlPlaneSpec{
+			Region: "the-region",
+			ControlPlaneEndpoint: capi.APIEndpoint{
+				Host: "https://eks123clusterID.sk1.eu-west-2.eks.amazonaws.com",
+				Port: 443,
+			},
+			NetworkSpec: capa.NetworkSpec{
+				VPC: capa.VPCSpec{
+					ID:        "vpc-1",
+					CidrBlock: fmt.Sprintf("10.%d.0.0/24", rand.Intn(255)),
+				},
+				Subnets: capa.Subnets{
+					{
+						ID:       "sub-1",
+						IsPublic: false,
+					},
+				},
+			},
+		},
+	}
+
+	return eksCluster
+}
+
+func createRandomCapaClusterWithIdentity(annotationsKeyValues ...string) (*capa.AWSClusterRoleIdentity, *capa.AWSCluster, *capi.Cluster) {
+	name := uuid.NewString()
+	awsCluster := newCapaCluster(name, annotationsKeyValues...)
+	capiCluster := newCapiCluster(name, annotationsKeyValues...)
+	identity := newRoleIdentity()
+
+	awsCluster.Spec.IdentityRef = &capa.AWSIdentityReference{
+		Name: identity.Name,
+		Kind: "AWSClusterRoleIdentity",
+	}
+
+	Expect(k8sClient.Create(context.Background(), capiCluster)).To(Succeed())
+	tests.PatchCAPIClusterStatus(k8sClient, capiCluster, capi.ClusterStatus{
+		Phase: "Running",
+	})
+
+	Expect(k8sClient.Create(context.Background(), awsCluster)).To(Succeed())
+	Expect(k8sClient.Create(context.Background(), identity)).To(Succeed())
+	tests.PatchAWSClusterStatus(k8sClient, awsCluster, capa.AWSClusterStatus{
+		Ready: true,
+	})
+
+	return identity, awsCluster, capiCluster
+}
+
+func createRandomAwsManagedControlplaneWithIdentity(annotationsKeyValues ...string) (*capa.AWSClusterRoleIdentity, *eks.AWSManagedControlPlane, *capi.Cluster) {
+	name := uuid.NewString()
+	eksCluster := newEksCluster(name, annotationsKeyValues...)
+	capiCluster := newCapiCluster(name, annotationsKeyValues...)
+	identity := newRoleIdentity()
+
+	capiCluster.Spec.InfrastructureRef = &corev1.ObjectReference{
+		Kind: "AWSManagedCluster",
+	}
+	capiCluster.Spec.ControlPlaneRef = &corev1.ObjectReference{
+		Kind: "AWSManagedControlPlane",
+	}
+
+	eksCluster.Spec.IdentityRef = &capa.AWSIdentityReference{
+		Name: identity.Name,
+		Kind: "AWSClusterRoleIdentity",
+	}
+
+	Expect(k8sClient.Create(context.Background(), capiCluster)).To(Succeed())
+	tests.PatchCAPIClusterStatus(k8sClient, capiCluster, capi.ClusterStatus{
+		Phase: "Running",
+	})
+
+	Expect(k8sClient.Create(context.Background(), eksCluster)).To(Succeed())
+	Expect(k8sClient.Create(context.Background(), identity)).To(Succeed())
+	tests.PatchEKSClusterStatus(k8sClient, eksCluster, eks.AWSManagedControlPlaneStatus{
+		Ready: true,
+	})
+
+	return identity, eksCluster, capiCluster
+}
+
+func newRoleIdentity() *capa.AWSClusterRoleIdentity {
+	name := uuid.NewString()
+	return &capa.AWSClusterRoleIdentity{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: capa.AWSClusterRoleIdentitySpec{
+			AWSRoleSpec: capa.AWSRoleSpec{
+				RoleArn: fmt.Sprintf("arn:aws:iam::%d:role/%s", rand.Intn(1000000), name),
+			},
+		},
+	}
 }

--- a/controllers/crossplane_config.go
+++ b/controllers/crossplane_config.go
@@ -1,0 +1,569 @@
+/*
+Copyright 2023.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"slices"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws/arn"
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metaerr "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	capa "sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
+	eks "sigs.k8s.io/cluster-api-provider-aws/v2/controlplane/eks/api/v1beta2"
+	capi "sigs.k8s.io/cluster-api/api/v1beta1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/yaml"
+)
+
+const Finalizer = "crossplane-config-operator.finalizers.giantswarm.io/config-map-controller"
+
+type ConfigMapReconciler struct {
+	Client       client.Client
+	BaseDomain   string
+	ProviderRole string
+}
+
+type ClusterInfo struct {
+	Name         string
+	Namespace    string
+	Region       string
+	AWSPartition string
+	VpcID        string
+	RoleArn      arn.ARN
+
+	// Only contains the primary OIDC domain. See also the plural variant below.
+	OIDCDomain string
+
+	// All service account issuer domains
+	OIDCDomains []string
+
+	SecurityGroups *crossplaneConfigValuesAWSClusterSecurityGroups
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *ConfigMapReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&capi.Cluster{}).
+		Complete(r)
+}
+
+func (r *ConfigMapReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := log.FromContext(ctx)
+
+	clusterInfo := &ClusterInfo{}
+
+	cluster := &capi.Cluster{}
+	err := r.Client.Get(ctx, req.NamespacedName, cluster)
+
+	if err != nil {
+		logger.Error(err, "failed to get cluster")
+		return ctrl.Result{}, errors.WithStack(client.IgnoreNotFound(err))
+	}
+
+	if !cluster.DeletionTimestamp.IsZero() {
+		logger.Info("Reconciling delete")
+		return r.reconcileDelete(ctx, cluster)
+	}
+
+	if IsEKS(*cluster) {
+		awsManagedControlPlane := &eks.AWSManagedControlPlane{}
+		err := r.Client.Get(ctx, req.NamespacedName, awsManagedControlPlane)
+		if err != nil {
+			logger.Error(err, "failed to get cluster")
+			return ctrl.Result{}, errors.WithStack(client.IgnoreNotFound(err))
+		}
+
+		clusterInfo.Name = awsManagedControlPlane.Name
+		clusterInfo.Namespace = awsManagedControlPlane.Namespace
+		clusterInfo.Region = awsManagedControlPlane.Spec.Region
+		clusterInfo.AWSPartition = getPartition(clusterInfo.Region)
+		clusterInfo.VpcID = awsManagedControlPlane.Spec.NetworkSpec.VPC.ID
+		clusterInfo.RoleArn, err = r.getRoleArn(ctx, awsManagedControlPlane.Spec.IdentityRef.Name, awsManagedControlPlane.Namespace)
+		if err != nil {
+			logger.Error(err, "failed to get cluster role identity")
+			return ctrl.Result{}, errors.WithStack(client.IgnoreNotFound(err))
+		}
+		eksId, err := getEKSId(awsManagedControlPlane.Spec.ControlPlaneEndpoint.Host)
+		if err != nil {
+			logger.Error(err, "failed to get EKS Cluster ID")
+			return ctrl.Result{}, errors.WithStack(client.IgnoreNotFound(err))
+		}
+
+		dnsSuffix := "amazonaws.com"
+
+		if clusterInfo.Region == "cn-north-1" || clusterInfo.Region == "cn-northwest-1" {
+			dnsSuffix = "amazonaws.com.cn"
+		}
+
+		clusterInfo.OIDCDomain = "oidc.eks." + clusterInfo.Region + "." + dnsSuffix + "/id/" + eksId
+		clusterInfo.OIDCDomains = []string{clusterInfo.OIDCDomain}
+
+	} else {
+		awsCluster := &capa.AWSCluster{}
+		err = r.Client.Get(ctx, req.NamespacedName, awsCluster)
+		if err != nil {
+			logger.Error(err, "failed to get cluster")
+			return ctrl.Result{}, errors.WithStack(client.IgnoreNotFound(err))
+		}
+		clusterInfo.Name = awsCluster.Name
+		clusterInfo.Namespace = awsCluster.Namespace
+		clusterInfo.Region = awsCluster.Spec.Region
+		clusterInfo.AWSPartition = getPartition(clusterInfo.Region)
+		clusterInfo.VpcID = awsCluster.Spec.NetworkSpec.VPC.ID
+		clusterInfo.RoleArn, err = r.getRoleArn(ctx, awsCluster.Spec.IdentityRef.Name, awsCluster.Namespace)
+		if err != nil {
+			logger.Error(err, "failed to get cluster role identity")
+			return ctrl.Result{}, errors.WithStack(client.IgnoreNotFound(err))
+		}
+
+		// May not apply to all clusters (e.g. different in China region), so we prefer reading the actual values
+		// from the `AWSCluster` annotation
+		computedIRSADomain := "irsa." + clusterInfo.Name + "." + r.BaseDomain
+		irsaTrustDomains := getIRSATrustDomains(awsCluster, computedIRSADomain)
+		clusterInfo.OIDCDomain = irsaTrustDomains[0]
+		clusterInfo.OIDCDomains = irsaTrustDomains
+
+		clusterInfo.SecurityGroups = &crossplaneConfigValuesAWSClusterSecurityGroups{}
+
+		if sg, ok := awsCluster.Status.Network.SecurityGroups[capa.SecurityGroupControlPlane]; ok {
+			clusterInfo.SecurityGroups.ControlPlane = &crossplaneConfigValuesAWSClusterSecurityGroup{
+				ID: sg.ID,
+			}
+		}
+
+		if sg, ok := awsCluster.Status.Network.SecurityGroups[capa.SecurityGroupNode]; ok {
+			clusterInfo.SecurityGroups.Node = &crossplaneConfigValuesAWSClusterSecurityGroup{
+				ID: sg.ID,
+			}
+		}
+	}
+
+	return r.reconcileNormal(ctx, clusterInfo)
+}
+
+func IsEKS(cluster capi.Cluster) bool {
+	return cluster.Spec.ControlPlaneRef != nil &&
+		cluster.Spec.ControlPlaneRef.Kind == "AWSManagedControlPlane"
+}
+
+func getEKSId(urlString string) (string, error) {
+	u, err := url.Parse(urlString)
+	if err != nil {
+		return "", err
+	}
+
+	// The host part of the URL is in the form of "ED3AA07D016EA49EEBC31AB274E7F3DD.sk1.eu-west-2.eks.amazonaws.com"
+	// We can split it by '.' and take the first part
+	parts := strings.Split(u.Hostname(), ".")
+	if len(parts) > 0 {
+		return parts[0], nil
+	}
+
+	return "", fmt.Errorf("unable to extract ID from URL")
+}
+
+func getIRSATrustDomains(awsCluster *capa.AWSCluster, fallbackComputedDomain string) []string {
+	annotations := awsCluster.GetAnnotations()
+	if annotations == nil {
+		annotations = map[string]string{}
+	}
+	if s := annotations["aws.giantswarm.io/irsa-trust-domains"]; s != "" {
+		irsaTrustDomains := []string{}
+		values := strings.Split(s, ",")
+		for _, value := range values {
+			value = strings.TrimSpace(value)
+			if value != "" && !slices.Contains(irsaTrustDomains, value) {
+				irsaTrustDomains = append(irsaTrustDomains, value)
+			}
+		}
+		if len(irsaTrustDomains) > 0 {
+			return irsaTrustDomains
+		}
+	}
+	return []string{fallbackComputedDomain}
+}
+
+func (r *ConfigMapReconciler) getRoleArn(ctx context.Context, idRef string, namespace string) (arn.ARN, error) {
+	logger := log.FromContext(ctx)
+	identity := &capa.AWSClusterRoleIdentity{}
+	err := r.Client.Get(
+		ctx,
+		types.NamespacedName{
+			Name:      idRef,
+			Namespace: namespace,
+		},
+		identity,
+	)
+	if err != nil {
+		return arn.ARN{}, errors.WithStack(err)
+	}
+
+	roleARN, err := arn.Parse(identity.Spec.RoleArn)
+	if err != nil {
+		logger.Error(err, "failed to parse role arn")
+		return arn.ARN{}, errors.WithStack(err)
+	}
+
+	return roleARN, nil
+}
+
+func (r *ConfigMapReconciler) reconcileNormal(ctx context.Context, clusterInfo *ClusterInfo) (ctrl.Result, error) {
+	logger := log.FromContext(ctx)
+	logger.Info("Reconciling")
+	defer logger.Info("Done reconciling")
+
+	capiCluster := &capi.Cluster{}
+	err := r.Client.Get(ctx, types.NamespacedName{
+		Name:      clusterInfo.Name,
+		Namespace: clusterInfo.Namespace,
+	}, capiCluster)
+	if err != nil {
+		logger.Error(err, "failed to get cluster")
+		return ctrl.Result{}, errors.WithStack(client.IgnoreNotFound(err))
+	}
+
+	err = r.AddFinalizer(ctx, capiCluster)
+	if err != nil {
+		logger.Error(err, "failed to add finalizer")
+		return ctrl.Result{}, errors.WithStack(err)
+	}
+
+	err = r.reconcileConfigMap(ctx, clusterInfo, clusterInfo.RoleArn.AccountID, r.BaseDomain)
+	if err != nil {
+		logger.Error(err, "failed to reconcile config map")
+		return ctrl.Result{}, errors.WithStack(err)
+
+	}
+
+	err = r.reconcileProviderConfig(ctx, clusterInfo, clusterInfo.RoleArn.AccountID)
+	if err != nil {
+		logger.Error(err, "failed to reconcile provider config")
+		return ctrl.Result{}, errors.WithStack(err)
+
+	}
+
+	return ctrl.Result{}, nil
+}
+
+type crossplaneConfigValues struct {
+	AccountID    string                           `json:"accountID"`
+	AWSCluster   crossplaneConfigValuesAWSCluster `json:"awsCluster"`
+	AWSPartition string                           `json:"awsPartition"`
+	BaseDomain   string                           `json:"baseDomain"`
+	ClusterName  string                           `json:"clusterName"`
+	Region       string                           `json:"region"`
+
+	// For backward compatibility, we still export the primary domain as singular-named field `oidcDomain`
+	OIDCDomain  string   `json:"oidcDomain"`
+	OIDCDomains []string `json:"oidcDomains"`
+}
+
+type crossplaneConfigValuesAWSCluster struct {
+	// Filled once available
+	VpcID          string                                          `json:"vpcId,omitempty"`
+	SecurityGroups *crossplaneConfigValuesAWSClusterSecurityGroups `json:"securityGroups,omitempty"`
+}
+
+type crossplaneConfigValuesAWSClusterSecurityGroups struct {
+	// Filled once available
+	ControlPlane *crossplaneConfigValuesAWSClusterSecurityGroup `json:"controlPlane,omitempty"`
+	Node         *crossplaneConfigValuesAWSClusterSecurityGroup `json:"node,omitempty"`
+}
+
+type crossplaneConfigValuesAWSClusterSecurityGroup struct {
+	ID string `json:"id"`
+}
+
+func (r *ConfigMapReconciler) reconcileConfigMap(ctx context.Context, clusterInfo *ClusterInfo, accountID, baseDomain string) error {
+	config := &corev1.ConfigMap{}
+	err := r.Client.Get(ctx,
+		types.NamespacedName{
+			Name:      fmt.Sprintf("%s-crossplane-config", clusterInfo.Name),
+			Namespace: clusterInfo.Namespace,
+		},
+		config,
+	)
+
+	if k8serrors.IsNotFound(err) {
+		return r.createConfigMap(ctx, clusterInfo, accountID, baseDomain)
+	}
+
+	return r.updateConfigMap(ctx, clusterInfo, config, accountID, baseDomain)
+}
+
+func (r *ConfigMapReconciler) reconcileProviderConfig(ctx context.Context, clusterInfo *ClusterInfo, accountID string) error {
+	logger := log.FromContext(ctx)
+
+	providerConfig := getProviderConfig(clusterInfo.Name, clusterInfo.Namespace)
+
+	err := r.Client.Get(ctx, types.NamespacedName{
+		Name:      clusterInfo.Name,
+		Namespace: clusterInfo.Namespace,
+	}, providerConfig)
+	if metaerr.IsNoMatchError(err) {
+		logger.Info("Provider config CRD not found, skipping provider config creation")
+		return nil
+	}
+	if k8serrors.IsNotFound(err) {
+		return r.createProviderConfig(ctx, providerConfig, accountID, clusterInfo.Region)
+	}
+	if err != nil {
+		logger.Error(err, "Failed to get provider config")
+		return errors.WithStack(err)
+	}
+
+	return r.updateProviderConfig(ctx, providerConfig, accountID, clusterInfo.Region)
+}
+
+func (r *ConfigMapReconciler) reconcileDelete(ctx context.Context, cluster *capi.Cluster) (ctrl.Result, error) {
+	logger := log.FromContext(ctx)
+	logger.Info("Reconcile delete")
+	defer logger.Info("Done deleting")
+
+	config := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("%s-crossplane-config", cluster.Name),
+			Namespace: cluster.Namespace,
+		},
+	}
+
+	logger.Info("Deleting ConfigMap")
+	err := r.Client.Delete(ctx, config)
+	if err != nil && !k8serrors.IsNotFound(err) {
+		logger.Error(err, "failed to delete config map")
+		return ctrl.Result{}, errors.WithStack(err)
+	}
+
+	providerConfig := getProviderConfig(cluster.Name, cluster.Namespace)
+	logger.Info("Deleting ProviderConfig")
+	err = r.Client.Delete(ctx, providerConfig)
+	if err != nil &&
+		!k8serrors.IsNotFound(err) &&
+		!metaerr.IsNoMatchError(err) {
+
+		logger.Error(err, "failed to delete provider config")
+		return ctrl.Result{}, errors.WithStack(err)
+	}
+
+	logger.Info("Removing Finalizer")
+	err = r.RemoveFinalizer(ctx, cluster)
+	if err != nil {
+		logger.Error(err, "failed to remove finalizer")
+		return ctrl.Result{}, errors.WithStack(err)
+	}
+
+	return ctrl.Result{}, nil
+}
+
+func (r *ConfigMapReconciler) AddFinalizer(ctx context.Context, cluster *capi.Cluster) error {
+	originalCluster := cluster.DeepCopy()
+	controllerutil.AddFinalizer(cluster, Finalizer)
+	return r.Client.Patch(ctx, cluster, client.MergeFrom(originalCluster))
+}
+
+func (r *ConfigMapReconciler) RemoveFinalizer(ctx context.Context, cluster *capi.Cluster) error {
+
+	// Check if there is an AWSCluster with the same name and namespace, and remove the finalizer. This enables the migration of the finalizer from `AWSCluster` to `Cluster`.
+	awsCluster := &capa.AWSCluster{}
+	err := r.Client.Get(ctx, types.NamespacedName{
+		Name:      cluster.Name,
+		Namespace: cluster.Namespace,
+	}, awsCluster)
+	if client.IgnoreNotFound(err) != nil {
+		return err
+	}
+	if err == nil {
+		originalAWSCluster := awsCluster.DeepCopy()
+		controllerutil.RemoveFinalizer(awsCluster, Finalizer)
+		err = r.Client.Patch(ctx, awsCluster, client.MergeFrom(originalAWSCluster))
+		if err != nil {
+			return err
+		}
+	}
+
+	originalCluster := cluster.DeepCopy()
+	controllerutil.RemoveFinalizer(cluster, Finalizer)
+	err = r.Client.Patch(ctx, cluster, client.MergeFrom(originalCluster))
+	if err != nil {
+		return err
+	}
+
+	return err
+}
+
+func (r *ConfigMapReconciler) createConfigMap(ctx context.Context, clusterInfo *ClusterInfo, accountID, baseDomain string) error {
+	logger := log.FromContext(ctx)
+
+	logger.Info("Creating config map")
+	configMapValues, err := getConfigMapValues(clusterInfo, accountID, baseDomain)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	config := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("%s-crossplane-config", clusterInfo.Name),
+			Namespace: clusterInfo.Namespace,
+			Labels: map[string]string{
+				"app.kubernetes.io/managed-by": "aws-crossplane-cluster-config-operator",
+			},
+		},
+		Data: map[string]string{
+			"values": configMapValues,
+		},
+	}
+
+	err = r.Client.Create(ctx, config)
+	if k8serrors.IsAlreadyExists(err) {
+		logger.Info("config map already exists")
+		return errors.WithStack(err)
+	}
+	if err != nil {
+		logger.Error(err, "failed to create config map")
+		return errors.WithStack(err)
+	}
+
+	return nil
+}
+
+func (r *ConfigMapReconciler) updateConfigMap(ctx context.Context,
+	clusterInfo *ClusterInfo,
+	config *corev1.ConfigMap,
+	accountID, baseDomain string,
+) error {
+	logger := log.FromContext(ctx)
+
+	configMapValues, err := getConfigMapValues(clusterInfo, accountID, baseDomain)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	patchedConfig := config.DeepCopy()
+	patchedConfig.Data["values"] = configMapValues
+
+	err = r.Client.Patch(ctx, patchedConfig, client.MergeFrom(config))
+	if err != nil {
+		logger.Error(err, "failed to patch config map")
+		return errors.WithStack(err)
+	}
+
+	return nil
+}
+
+func (r *ConfigMapReconciler) createProviderConfig(ctx context.Context, providerConfig *unstructured.Unstructured, accountID, region string) error {
+	logger := log.FromContext(ctx)
+
+	providerConfig.Object["spec"] = r.getProviderConfigSpec(accountID, region)
+
+	err := r.Client.Create(ctx, providerConfig)
+	if k8serrors.IsAlreadyExists(err) {
+		logger.Info("provider config already exists")
+		return nil
+	}
+	if err != nil {
+		logger.Error(err, "failed to create provider config")
+		return errors.WithStack(err)
+	}
+
+	return nil
+}
+
+func (r *ConfigMapReconciler) updateProviderConfig(ctx context.Context, providerConfig *unstructured.Unstructured, accountID, region string) error {
+	logger := log.FromContext(ctx)
+
+	patchedConfig := providerConfig.DeepCopy()
+	patchedConfig.Object["spec"] = r.getProviderConfigSpec(accountID, region)
+	err := r.Client.Patch(ctx, patchedConfig, client.MergeFrom(providerConfig))
+	if err != nil {
+		logger.Error(err, "Failed to patch provider config")
+		return errors.WithStack(err)
+	}
+
+	return nil
+}
+
+func (r *ConfigMapReconciler) getProviderConfigSpec(accountID, region string) map[string]interface{} {
+	partition := getPartition(region)
+	return map[string]interface{}{
+		"credentials": map[string]interface{}{
+			"source": "WebIdentity",
+			"webIdentity": map[string]interface{}{
+				"roleARN": fmt.Sprintf("arn:%s:iam::%s:role/%s", partition, accountID, r.ProviderRole),
+			},
+		},
+	}
+}
+
+func getConfigMapValues(clusterInfo *ClusterInfo, accountID, baseDomain string) (string, error) {
+	valuesAWSCluster := crossplaneConfigValuesAWSCluster{}
+	valuesAWSCluster.VpcID = clusterInfo.VpcID
+	valuesAWSCluster.SecurityGroups = clusterInfo.SecurityGroups
+
+	values := crossplaneConfigValues{
+		AccountID:    accountID,
+		AWSCluster:   valuesAWSCluster,
+		AWSPartition: clusterInfo.AWSPartition,
+		BaseDomain:   fmt.Sprintf("%s.%s", clusterInfo.Name, baseDomain),
+		ClusterName:  clusterInfo.Name,
+		Region:       clusterInfo.Region,
+		OIDCDomain:   clusterInfo.OIDCDomains[0],
+		OIDCDomains:  clusterInfo.OIDCDomains,
+	}
+
+	configMapValues, err := yaml.Marshal(values)
+	if err != nil {
+		return "", errors.WithStack(err)
+	}
+
+	return string(configMapValues), nil
+}
+
+func getProviderConfig(name string, namespace string) *unstructured.Unstructured {
+	providerConfig := &unstructured.Unstructured{}
+	providerConfig.Object = map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"name":      name,
+			"namespace": namespace,
+		},
+	}
+	providerConfig.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "aws.upbound.io",
+		Kind:    "ProviderConfig",
+		Version: "v1beta1",
+	})
+
+	return providerConfig
+}
+
+func getPartition(region string) string {
+	if strings.HasPrefix(region, "cn-") {
+		return "aws-cn"
+	}
+	return "aws"
+}

--- a/controllers/crossplane_config.go
+++ b/controllers/crossplane_config.go
@@ -442,7 +442,7 @@ func (r *CrossplaneClusterConfigReconciler) createConfigMap(ctx context.Context,
 			Name:      fmt.Sprintf("%s-crossplane-config", clusterInfo.Name),
 			Namespace: clusterInfo.Namespace,
 			Labels: map[string]string{
-				"app.kubernetes.io/managed-by": "aws-crossplane-cluster-config-operator",
+				"app.kubernetes.io/managed-by": "aws-resolver-rules-operator",
 			},
 		},
 		Data: map[string]string{

--- a/controllers/crossplane_config_capa_test.go
+++ b/controllers/crossplane_config_capa_test.go
@@ -1,0 +1,405 @@
+package controllers_test
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws/arn"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	capa "sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
+	capi "sigs.k8s.io/cluster-api/api/v1beta1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/aws-resolver-rules-operator/controllers"
+)
+
+var _ = Describe("ConfigMapReconcilerCAPA", func() {
+	var (
+		ctx context.Context
+
+		accountID  string
+		identity   *capa.AWSClusterRoleIdentity
+		awsCluster *capa.AWSCluster
+		cluster    *capi.Cluster
+
+		request    ctrl.Request
+		reconciler *controllers.ConfigMapReconciler
+	)
+
+	verifyConfigMap := func() {
+		configMap := &corev1.ConfigMap{}
+		err := k8sClient.Get(ctx, types.NamespacedName{
+			Namespace: cluster.Namespace,
+			Name:      fmt.Sprintf("%s-crossplane-config", cluster.Name),
+		}, configMap)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(configMap.Data).To(HaveKeyWithValue("values", MatchYAML(fmt.Sprintf(`
+                accountID: "%s"
+                awsCluster:
+                  securityGroups: {}
+                  vpcId: vpc-1
+                baseDomain: %s.base.domain.io
+                clusterName: %s
+                oidcDomain: irsa.%s.base.domain.io
+                oidcDomains:
+                - irsa.%s.base.domain.io
+                region: the-region
+                awsPartition: aws
+            `, accountID, cluster.Name, cluster.Name, cluster.Name, cluster.Name))))
+	}
+
+	verifyProviderConfig := func() {
+		providerConfig := &unstructured.Unstructured{}
+		providerConfig.SetGroupVersionKind(schema.GroupVersionKind{
+			Group:   "aws.upbound.io",
+			Kind:    "ProviderConfig",
+			Version: "v1beta1",
+		})
+
+		err := k8sClient.Get(ctx, types.NamespacedName{
+			Namespace: cluster.Namespace,
+			Name:      cluster.Name,
+		}, providerConfig)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(providerConfig.Object).To(HaveKeyWithValue("metadata", MatchKeys(IgnoreExtras, Keys{
+			"name": Equal(cluster.Name),
+		})))
+		Expect(providerConfig.Object).To(HaveKeyWithValue("spec", MatchKeys(IgnoreExtras, Keys{
+			"credentials": MatchKeys(IgnoreExtras, Keys{
+				"source": Equal("WebIdentity"),
+				"webIdentity": MatchKeys(IgnoreExtras, Keys{
+					"roleARN": Equal(fmt.Sprintf("arn:aws:iam::%s:role/the-provider-role", accountID)),
+				}),
+			}),
+		})))
+	}
+
+	BeforeEach(func() {
+		ctx = context.Background()
+
+		identity, awsCluster, cluster = createRandomCapaClusterWithIdentity()
+		reconciler = &controllers.ConfigMapReconciler{
+			Client:       k8sClient,
+			BaseDomain:   "base.domain.io",
+			ProviderRole: "the-provider-role",
+		}
+		roleARN, err := arn.Parse(identity.Spec.RoleArn)
+		Expect(err).NotTo(HaveOccurred())
+		accountID = roleARN.AccountID
+
+		request = ctrl.Request{
+			NamespacedName: types.NamespacedName{
+				Namespace: awsCluster.Namespace,
+				Name:      awsCluster.Name,
+			},
+		}
+	})
+
+	JustBeforeEach(func() {
+		result, err := reconciler.Reconcile(ctx, request)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.Requeue).To(BeFalse())
+	})
+
+	AfterEach(func() {
+		err := k8sClient.Delete(ctx, cluster)
+		if k8serrors.IsNotFound(err) {
+			return
+		}
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	JustBeforeEach(func() {
+		result, err := reconciler.Reconcile(ctx, request)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.Requeue).To(BeFalse())
+	})
+
+	It("creates the configmap", func() {
+		verifyConfigMap()
+	})
+
+	It("creates the provider config", func() {
+		verifyProviderConfig()
+	})
+
+	When("the account id changes", func() {
+		BeforeEach(func() {
+			someOtherAccount := "1234567"
+			configMap := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: cluster.Namespace,
+					Name:      fmt.Sprintf("%s-crossplane-config", cluster.Name),
+				},
+			}
+			configMap.Data = map[string]string{
+				"values": fmt.Sprintf(`
+                    accountID: "%s"
+                    awsCluster:
+                        securityGroups: {}
+                        vpcId: vpc-1
+                    awsPartition: cn
+                    baseDomain: %s.base.domain.io
+                    oidcDomain: irsa.%s.base.domain.io
+                    oidcDomains:
+                    - irsa.%s.base.domain.io
+                    clusterName: %s
+                    region: some-other-region
+                `, someOtherAccount, cluster.Name, cluster.Name, cluster.Name, cluster.Name),
+			}
+			err := k8sClient.Create(ctx, configMap)
+			Expect(err).NotTo(HaveOccurred())
+
+			providerConfig := &unstructured.Unstructured{}
+			providerConfig.Object = map[string]interface{}{
+				"metadata": map[string]interface{}{
+					"name":      cluster.Name,
+					"namespace": cluster.Namespace,
+				},
+				"spec": map[string]interface{}{
+					"credentials": map[string]interface{}{
+						"source": "WebIdentity",
+						"webIdentity": map[string]interface{}{
+							"roleARN": fmt.Sprintf("arn:aws:iam::%s:role/some-other-provider-role", someOtherAccount),
+						},
+					},
+				},
+			}
+			providerConfig.SetGroupVersionKind(schema.GroupVersionKind{
+				Group:   "aws.upbound.io",
+				Kind:    "ProviderConfig",
+				Version: "v1beta1",
+			})
+			err = k8sClient.Create(ctx, providerConfig)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("updates the configmap", func() {
+			verifyConfigMap()
+		})
+
+		It("updates the provider config", func() {
+			verifyProviderConfig()
+		})
+	})
+
+	When("the cluster is deleted", func() {
+		BeforeEach(func() {
+			patchedCluster := cluster.DeepCopy()
+			patchedCluster.Finalizers = []string{controllers.Finalizer}
+
+			err := k8sClient.Patch(context.Background(), patchedCluster, client.MergeFrom(cluster))
+			Expect(err).NotTo(HaveOccurred())
+
+			err = k8sClient.Delete(context.Background(), cluster)
+			Expect(err).NotTo(HaveOccurred())
+
+			patchedCapaCluster := awsCluster.DeepCopy()
+			patchedCapaCluster.Finalizers = []string{controllers.Finalizer}
+
+			err = k8sClient.Patch(context.Background(), patchedCapaCluster, client.MergeFrom(awsCluster))
+			Expect(err).NotTo(HaveOccurred())
+
+			err = k8sClient.Delete(context.Background(), awsCluster)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("removes the finalizer on Cluster", func() {
+			err := k8sClient.Get(ctx, types.NamespacedName{
+				Namespace: cluster.Namespace,
+				Name:      cluster.Name,
+			}, cluster)
+			Expect(k8serrors.IsNotFound(err)).To(BeTrue())
+		})
+
+		It("removes the finalizer on AWSCluster", func() {
+			err := k8sClient.Get(ctx, types.NamespacedName{
+				Namespace: cluster.Namespace,
+				Name:      cluster.Name,
+			}, awsCluster)
+			Expect(k8serrors.IsNotFound(err)).To(BeTrue())
+		})
+
+		It("removes the config map", func() {
+			configMap := &corev1.ConfigMap{}
+			err := k8sClient.Get(ctx, types.NamespacedName{
+				Namespace: cluster.Namespace,
+				Name:      fmt.Sprintf("%s-crossplane-config", cluster.Name),
+			}, configMap)
+			Expect(k8serrors.IsNotFound(err)).To(BeTrue())
+		})
+
+		It("removes the providerconfig", func() {
+			providerConfig := &unstructured.Unstructured{}
+			providerConfig.SetGroupVersionKind(schema.GroupVersionKind{
+				Group:   "aws.upbound.io",
+				Kind:    "ProviderConfig",
+				Version: "v1beta1",
+			})
+
+			err := k8sClient.Get(ctx, types.NamespacedName{
+				Namespace: cluster.Namespace,
+				Name:      cluster.Name,
+			}, providerConfig)
+			Expect(k8serrors.IsNotFound(err)).To(BeTrue())
+		})
+	})
+
+	When("the cluster is in china", func() {
+		BeforeEach(func() {
+			awsCluster.Spec.Region = "cn-north-1"
+			err := k8sClient.Update(ctx, awsCluster)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("creates the configmap with the correct aws partition", func() {
+			configMap := &corev1.ConfigMap{}
+			err := k8sClient.Get(ctx, types.NamespacedName{
+				Namespace: cluster.Namespace,
+				Name:      fmt.Sprintf("%s-crossplane-config", cluster.Name),
+			}, configMap)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(configMap.Data).To(HaveKeyWithValue("values", MatchYAML(fmt.Sprintf(`
+                accountID: "%s"
+                awsCluster:
+                  securityGroups: {}
+                  vpcId: vpc-1
+                baseDomain: %s.base.domain.io
+                oidcDomain: irsa.%s.base.domain.io
+                oidcDomains:
+                - irsa.%s.base.domain.io
+                clusterName: %s
+                region: cn-north-1
+                awsPartition: aws-cn
+            `, accountID, cluster.Name, cluster.Name, cluster.Name, cluster.Name))))
+		})
+
+		It("creates the provider config with the correct aws partition", func() {
+			providerConfig := &unstructured.Unstructured{}
+			providerConfig.SetGroupVersionKind(schema.GroupVersionKind{
+				Group:   "aws.upbound.io",
+				Kind:    "ProviderConfig",
+				Version: "v1beta1",
+			})
+
+			err := k8sClient.Get(ctx, types.NamespacedName{
+				Namespace: cluster.Namespace,
+				Name:      cluster.Name,
+			}, providerConfig)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(providerConfig.Object).To(HaveKeyWithValue("metadata", MatchKeys(IgnoreExtras, Keys{
+				"name": Equal(cluster.Name),
+			})))
+			Expect(providerConfig.Object).To(HaveKeyWithValue("spec", MatchKeys(IgnoreExtras, Keys{
+				"credentials": MatchKeys(IgnoreExtras, Keys{
+					"source": Equal("WebIdentity"),
+					"webIdentity": MatchKeys(IgnoreExtras, Keys{
+						"roleARN": Equal(fmt.Sprintf("arn:aws-cn:iam::%s:role/the-provider-role", accountID)),
+					}),
+				}),
+			})))
+		})
+	})
+
+	When("the cluster is provisioned by CAPA", func() {
+		BeforeEach(func() {
+			awsCluster.Spec.NetworkSpec.VPC.ID = "vpc-123456"
+			err := k8sClient.Update(ctx, awsCluster)
+			Expect(err).NotTo(HaveOccurred())
+
+			awsCluster.Status.Network.SecurityGroups = map[capa.SecurityGroupRole]capa.SecurityGroup{
+				capa.SecurityGroupControlPlane: {
+					ID: "sg-789987",
+				},
+				capa.SecurityGroupNode: {
+					ID: "sg-898989",
+				},
+			}
+			err = k8sClient.Status().Update(ctx, awsCluster)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("creates the configmap with the correct VPC ID and security group ID(s)", func() {
+			configMap := &corev1.ConfigMap{}
+			err := k8sClient.Get(ctx, types.NamespacedName{
+				Namespace: cluster.Namespace,
+				Name:      fmt.Sprintf("%s-crossplane-config", cluster.Name),
+			}, configMap)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(configMap.Data).To(HaveKeyWithValue("values", MatchYAML(fmt.Sprintf(`
+                accountID: "%s"
+                awsCluster:
+                  securityGroups:
+                    controlPlane:
+                      id: sg-789987
+                    node:
+                      id: sg-898989
+                  vpcId: vpc-123456
+                awsPartition: aws
+                baseDomain: %s.base.domain.io
+                oidcDomain: irsa.%s.base.domain.io
+                oidcDomains:
+                - irsa.%s.base.domain.io
+                clusterName: %s
+                region: the-region
+            `, accountID, cluster.Name, cluster.Name, cluster.Name, cluster.Name))))
+		})
+	})
+
+	When("the cluster has multiple service account issuers defined by an annotation", func() {
+		BeforeEach(func() {
+			awsCluster.Spec.NetworkSpec.VPC.ID = "vpc-123456"
+			if awsCluster.Annotations == nil {
+				awsCluster.Annotations = map[string]string{}
+			}
+			awsCluster.Annotations["aws.giantswarm.io/irsa-trust-domains"] = "first,second"
+			err := k8sClient.Update(ctx, awsCluster)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("creates the configmap with the correct service account issuer domains", func() {
+			configMap := &corev1.ConfigMap{}
+			err := k8sClient.Get(ctx, types.NamespacedName{
+				Namespace: cluster.Namespace,
+				Name:      fmt.Sprintf("%s-crossplane-config", cluster.Name),
+			}, configMap)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(configMap.Data).To(HaveKeyWithValue("values", MatchYAML(fmt.Sprintf(`
+                accountID: "%s"
+                awsCluster:
+                  securityGroups: {}
+                  vpcId: vpc-123456
+                awsPartition: aws
+                baseDomain: %s.base.domain.io
+                oidcDomain: first
+                oidcDomains:
+                - first
+                - second
+                clusterName: %s
+                region: the-region
+            `, accountID, cluster.Name, cluster.Name))))
+		})
+	})
+
+	When("the role arn is invalid", func() {
+		It("returns an error", func() {
+			identity.Spec.RoleArn = "invalid-arn"
+			err := k8sClient.Update(ctx, identity)
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = reconciler.Reconcile(ctx, request)
+			Expect(err).To(HaveOccurred())
+		})
+	})
+})

--- a/controllers/crossplane_config_capa_test.go
+++ b/controllers/crossplane_config_capa_test.go
@@ -24,7 +24,7 @@ import (
 
 const ManagementClusterName = "mcname"
 
-var _ = Describe("ConfigMapReconcilerCAPA", func() {
+var _ = Describe("CrossplaneClusterConfigMapReconcilerCAPA", func() {
 	var (
 		ctx context.Context
 
@@ -34,7 +34,7 @@ var _ = Describe("ConfigMapReconcilerCAPA", func() {
 		cluster    *capi.Cluster
 
 		request    ctrl.Request
-		reconciler *controllers.ConfigMapReconciler
+		reconciler *controllers.CrossplaneClusterConfigReconciler
 	)
 
 	verifyConfigMap := func() {
@@ -90,7 +90,7 @@ var _ = Describe("ConfigMapReconcilerCAPA", func() {
 		ctx = context.Background()
 
 		identity, awsCluster, cluster = createRandomCapaClusterWithIdentity()
-		reconciler = &controllers.ConfigMapReconciler{
+		reconciler = &controllers.CrossplaneClusterConfigReconciler{
 			Client:                k8sClient,
 			BaseDomain:            "base.domain.io",
 			ManagementClusterName: ManagementClusterName,

--- a/controllers/crossplane_config_capa_test.go
+++ b/controllers/crossplane_config_capa_test.go
@@ -22,6 +22,8 @@ import (
 	"github.com/aws-resolver-rules-operator/controllers"
 )
 
+const ManagementClusterName = "mcname"
+
 var _ = Describe("ConfigMapReconcilerCAPA", func() {
 	var (
 		ctx context.Context
@@ -78,7 +80,7 @@ var _ = Describe("ConfigMapReconcilerCAPA", func() {
 			"credentials": MatchKeys(IgnoreExtras, Keys{
 				"source": Equal("WebIdentity"),
 				"webIdentity": MatchKeys(IgnoreExtras, Keys{
-					"roleARN": Equal(fmt.Sprintf("arn:aws:iam::%s:role/the-provider-role", accountID)),
+					"roleARN": Equal(fmt.Sprintf("arn:aws:iam::%s:role/giantswarm-%s-capa-controller", accountID, ManagementClusterName)),
 				}),
 			}),
 		})))
@@ -89,9 +91,9 @@ var _ = Describe("ConfigMapReconcilerCAPA", func() {
 
 		identity, awsCluster, cluster = createRandomCapaClusterWithIdentity()
 		reconciler = &controllers.ConfigMapReconciler{
-			Client:       k8sClient,
-			BaseDomain:   "base.domain.io",
-			ProviderRole: "the-provider-role",
+			Client:                k8sClient,
+			BaseDomain:            "base.domain.io",
+			ManagementClusterName: ManagementClusterName,
 		}
 		roleARN, err := arn.Parse(identity.Spec.RoleArn)
 		Expect(err).NotTo(HaveOccurred())
@@ -305,7 +307,7 @@ var _ = Describe("ConfigMapReconcilerCAPA", func() {
 				"credentials": MatchKeys(IgnoreExtras, Keys{
 					"source": Equal("WebIdentity"),
 					"webIdentity": MatchKeys(IgnoreExtras, Keys{
-						"roleARN": Equal(fmt.Sprintf("arn:aws-cn:iam::%s:role/the-provider-role", accountID)),
+						"roleARN": Equal(fmt.Sprintf("arn:aws-cn:iam::%s:role/giantswarm-%s-capa-controller", accountID, ManagementClusterName)),
 					}),
 				}),
 			})))

--- a/controllers/crossplane_config_eks_test.go
+++ b/controllers/crossplane_config_eks_test.go
@@ -1,0 +1,343 @@
+package controllers_test
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws/arn"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	capa "sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
+	eks "sigs.k8s.io/cluster-api-provider-aws/v2/controlplane/eks/api/v1beta2"
+	capi "sigs.k8s.io/cluster-api/api/v1beta1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/aws-resolver-rules-operator/controllers"
+)
+
+var _ = Describe("ConfigMapReconcilerEKS", func() {
+	var (
+		ctx context.Context
+
+		accountID              string
+		identity               *capa.AWSClusterRoleIdentity
+		awsManagedControlplane *eks.AWSManagedControlPlane
+		cluster                *capi.Cluster
+
+		request    ctrl.Request
+		reconciler *controllers.ConfigMapReconciler
+	)
+
+	verifyConfigMap := func() {
+		configMap := &corev1.ConfigMap{}
+		err := k8sClient.Get(ctx, types.NamespacedName{
+			Namespace: cluster.Namespace,
+			Name:      fmt.Sprintf("%s-crossplane-config", cluster.Name),
+		}, configMap)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(configMap.Data).To(HaveKeyWithValue("values", MatchYAML(fmt.Sprintf(`
+                accountID: "%s"
+                awsCluster:
+                  vpcId: vpc-1
+                baseDomain: %s.base.domain.io
+                clusterName: %s
+                oidcDomain: oidc.eks.the-region.amazonaws.com/id/eks123clusterID
+                oidcDomains:
+                - oidc.eks.the-region.amazonaws.com/id/eks123clusterID
+                region: the-region
+                awsPartition: aws
+            `, accountID, cluster.Name, cluster.Name))))
+	}
+
+	verifyProviderConfig := func() {
+		providerConfig := &unstructured.Unstructured{}
+		providerConfig.SetGroupVersionKind(schema.GroupVersionKind{
+			Group:   "aws.upbound.io",
+			Kind:    "ProviderConfig",
+			Version: "v1beta1",
+		})
+
+		err := k8sClient.Get(ctx, types.NamespacedName{
+			Namespace: cluster.Namespace,
+			Name:      cluster.Name,
+		}, providerConfig)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(providerConfig.Object).To(HaveKeyWithValue("metadata", MatchKeys(IgnoreExtras, Keys{
+			"name": Equal(cluster.Name),
+		})))
+		Expect(providerConfig.Object).To(HaveKeyWithValue("spec", MatchKeys(IgnoreExtras, Keys{
+			"credentials": MatchKeys(IgnoreExtras, Keys{
+				"source": Equal("WebIdentity"),
+				"webIdentity": MatchKeys(IgnoreExtras, Keys{
+					"roleARN": Equal(fmt.Sprintf("arn:aws:iam::%s:role/the-provider-role", accountID)),
+				}),
+			}),
+		})))
+	}
+
+	BeforeEach(func() {
+		ctx = context.Background()
+
+		identity, awsManagedControlplane, cluster = createRandomAwsManagedControlplaneWithIdentity()
+		reconciler = &controllers.ConfigMapReconciler{
+			Client:       k8sClient,
+			BaseDomain:   "base.domain.io",
+			ProviderRole: "the-provider-role",
+		}
+		roleARN, err := arn.Parse(identity.Spec.RoleArn)
+		Expect(err).NotTo(HaveOccurred())
+		accountID = roleARN.AccountID
+
+		request = ctrl.Request{
+			NamespacedName: types.NamespacedName{
+				Namespace: awsManagedControlplane.Namespace,
+				Name:      awsManagedControlplane.Name,
+			},
+		}
+	})
+
+	JustBeforeEach(func() {
+		result, err := reconciler.Reconcile(ctx, request)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.Requeue).To(BeFalse())
+	})
+
+	AfterEach(func() {
+		err := k8sClient.Delete(ctx, cluster)
+		if k8serrors.IsNotFound(err) {
+			return
+		}
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	JustBeforeEach(func() {
+		result, err := reconciler.Reconcile(ctx, request)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.Requeue).To(BeFalse())
+	})
+
+	It("creates the configmap", func() {
+		verifyConfigMap()
+	})
+
+	It("creates the provider config", func() {
+		verifyProviderConfig()
+	})
+
+	When("the account id changes", func() {
+		BeforeEach(func() {
+			someOtherAccount := "1234567"
+			configMap := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: cluster.Namespace,
+					Name:      fmt.Sprintf("%s-crossplane-config", cluster.Name),
+				},
+			}
+			configMap.Data = map[string]string{
+				"values": fmt.Sprintf(`
+                    accountID: "%s"
+                    awsCluster:
+                        vpcId: vpc-1
+                    awsPartition: cn
+                    baseDomain: %s.base.domain.io
+                    oidcDomain: oidc.eks.some-other-region.amazonaws.com.cn/id/eks123clusterID
+                    oidcDomains:
+                    - oidc.eks.some-other-region.amazonaws.com.cn/id/eks123clusterID
+                    clusterName: %s
+                    region: some-other-region
+                `, someOtherAccount, cluster.Name, cluster.Name),
+			}
+			err := k8sClient.Create(ctx, configMap)
+			Expect(err).NotTo(HaveOccurred())
+
+			providerConfig := &unstructured.Unstructured{}
+			providerConfig.Object = map[string]interface{}{
+				"metadata": map[string]interface{}{
+					"name":      cluster.Name,
+					"namespace": cluster.Namespace,
+				},
+				"spec": map[string]interface{}{
+					"credentials": map[string]interface{}{
+						"source": "WebIdentity",
+						"webIdentity": map[string]interface{}{
+							"roleARN": fmt.Sprintf("arn:aws:iam::%s:role/some-other-provider-role", someOtherAccount),
+						},
+					},
+				},
+			}
+			providerConfig.SetGroupVersionKind(schema.GroupVersionKind{
+				Group:   "aws.upbound.io",
+				Kind:    "ProviderConfig",
+				Version: "v1beta1",
+			})
+			err = k8sClient.Create(ctx, providerConfig)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("updates the configmap", func() {
+			verifyConfigMap()
+		})
+
+		It("updates the provider config", func() {
+			verifyProviderConfig()
+		})
+	})
+
+	When("the cluster is deleted", func() {
+		BeforeEach(func() {
+			patchedCluster := cluster.DeepCopy()
+			patchedCluster.Finalizers = []string{controllers.Finalizer}
+
+			err := k8sClient.Patch(context.Background(), patchedCluster, client.MergeFrom(cluster))
+			Expect(err).NotTo(HaveOccurred())
+
+			err = k8sClient.Delete(context.Background(), cluster)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("removes the finalizer", func() {
+			err := k8sClient.Get(ctx, types.NamespacedName{
+				Namespace: cluster.Namespace,
+				Name:      cluster.Name,
+			}, cluster)
+			Expect(k8serrors.IsNotFound(err)).To(BeTrue())
+		})
+
+		It("removes the config map", func() {
+			configMap := &corev1.ConfigMap{}
+			err := k8sClient.Get(ctx, types.NamespacedName{
+				Namespace: cluster.Namespace,
+				Name:      fmt.Sprintf("%s-crossplane-config", cluster.Name),
+			}, configMap)
+			Expect(k8serrors.IsNotFound(err)).To(BeTrue())
+		})
+
+		It("removes the providerconfig", func() {
+			providerConfig := &unstructured.Unstructured{}
+			providerConfig.SetGroupVersionKind(schema.GroupVersionKind{
+				Group:   "aws.upbound.io",
+				Kind:    "ProviderConfig",
+				Version: "v1beta1",
+			})
+
+			err := k8sClient.Get(ctx, types.NamespacedName{
+				Namespace: cluster.Namespace,
+				Name:      cluster.Name,
+			}, providerConfig)
+			Expect(k8serrors.IsNotFound(err)).To(BeTrue())
+		})
+	})
+
+	When("the cluster is in china", func() {
+		BeforeEach(func() {
+			awsManagedControlplane.Spec.Region = "cn-north-1"
+			err := k8sClient.Update(ctx, awsManagedControlplane)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("creates the configmap with the correct aws partition", func() {
+			configMap := &corev1.ConfigMap{}
+			err := k8sClient.Get(ctx, types.NamespacedName{
+				Namespace: cluster.Namespace,
+				Name:      fmt.Sprintf("%s-crossplane-config", cluster.Name),
+			}, configMap)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(configMap.Data).To(HaveKeyWithValue("values", MatchYAML(fmt.Sprintf(`
+                accountID: "%s"
+                awsCluster:
+                  vpcId: vpc-1
+                baseDomain: %s.base.domain.io
+                oidcDomain: oidc.eks.cn-north-1.amazonaws.com.cn/id/eks123clusterID
+                oidcDomains:
+                - oidc.eks.cn-north-1.amazonaws.com.cn/id/eks123clusterID
+                clusterName: %s
+                region: cn-north-1
+                awsPartition: aws-cn
+            `, accountID, cluster.Name, cluster.Name))))
+		})
+
+		It("creates the provider config with the correct aws partition", func() {
+			providerConfig := &unstructured.Unstructured{}
+			providerConfig.SetGroupVersionKind(schema.GroupVersionKind{
+				Group:   "aws.upbound.io",
+				Kind:    "ProviderConfig",
+				Version: "v1beta1",
+			})
+
+			err := k8sClient.Get(ctx, types.NamespacedName{
+				Namespace: cluster.Namespace,
+				Name:      cluster.Name,
+			}, providerConfig)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(providerConfig.Object).To(HaveKeyWithValue("metadata", MatchKeys(IgnoreExtras, Keys{
+				"name": Equal(cluster.Name),
+			})))
+			Expect(providerConfig.Object).To(HaveKeyWithValue("spec", MatchKeys(IgnoreExtras, Keys{
+				"credentials": MatchKeys(IgnoreExtras, Keys{
+					"source": Equal("WebIdentity"),
+					"webIdentity": MatchKeys(IgnoreExtras, Keys{
+						"roleARN": Equal(fmt.Sprintf("arn:aws-cn:iam::%s:role/the-provider-role", accountID)),
+					}),
+				}),
+			})))
+		})
+	})
+
+	When("the cluster is provisioned by CAPA", func() {
+		BeforeEach(func() {
+			awsManagedControlplane.Spec.NetworkSpec.VPC.ID = "vpc-123456"
+			err := k8sClient.Update(ctx, awsManagedControlplane)
+			Expect(err).NotTo(HaveOccurred())
+
+			awsManagedControlplane.Status.Network.SecurityGroups = map[capa.SecurityGroupRole]capa.SecurityGroup{
+				capa.SecurityGroupControlPlane: {
+					ID: "sg-789987",
+				},
+			}
+			err = k8sClient.Status().Update(ctx, awsManagedControlplane)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("creates the configmap with the correct VPC ID and security group ID(s)", func() {
+			configMap := &corev1.ConfigMap{}
+			err := k8sClient.Get(ctx, types.NamespacedName{
+				Namespace: cluster.Namespace,
+				Name:      fmt.Sprintf("%s-crossplane-config", cluster.Name),
+			}, configMap)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(configMap.Data).To(HaveKeyWithValue("values", MatchYAML(fmt.Sprintf(`
+                accountID: "%s"
+                awsCluster:
+                  vpcId: vpc-123456
+                awsPartition: aws
+                baseDomain: %s.base.domain.io
+                oidcDomain: oidc.eks.the-region.amazonaws.com/id/eks123clusterID
+                oidcDomains:
+                - oidc.eks.the-region.amazonaws.com/id/eks123clusterID
+                clusterName: %s
+                region: the-region
+            `, accountID, cluster.Name, cluster.Name))))
+		})
+	})
+
+	When("the role arn is invalid", func() {
+		It("returns an error", func() {
+			identity.Spec.RoleArn = "invalid-arn"
+			err := k8sClient.Update(ctx, identity)
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = reconciler.Reconcile(ctx, request)
+			Expect(err).To(HaveOccurred())
+		})
+	})
+})

--- a/controllers/crossplane_config_eks_test.go
+++ b/controllers/crossplane_config_eks_test.go
@@ -78,7 +78,7 @@ var _ = Describe("ConfigMapReconcilerEKS", func() {
 			"credentials": MatchKeys(IgnoreExtras, Keys{
 				"source": Equal("WebIdentity"),
 				"webIdentity": MatchKeys(IgnoreExtras, Keys{
-					"roleARN": Equal(fmt.Sprintf("arn:aws:iam::%s:role/the-provider-role", accountID)),
+					"roleARN": Equal(fmt.Sprintf("arn:aws:iam::%s:role/giantswarm-%s-capa-controller", accountID, ManagementClusterName)),
 				}),
 			}),
 		})))
@@ -89,9 +89,9 @@ var _ = Describe("ConfigMapReconcilerEKS", func() {
 
 		identity, awsManagedControlplane, cluster = createRandomAwsManagedControlplaneWithIdentity()
 		reconciler = &controllers.ConfigMapReconciler{
-			Client:       k8sClient,
-			BaseDomain:   "base.domain.io",
-			ProviderRole: "the-provider-role",
+			Client:                k8sClient,
+			BaseDomain:            "base.domain.io",
+			ManagementClusterName: ManagementClusterName,
 		}
 		roleARN, err := arn.Parse(identity.Spec.RoleArn)
 		Expect(err).NotTo(HaveOccurred())
@@ -286,7 +286,7 @@ var _ = Describe("ConfigMapReconcilerEKS", func() {
 				"credentials": MatchKeys(IgnoreExtras, Keys{
 					"source": Equal("WebIdentity"),
 					"webIdentity": MatchKeys(IgnoreExtras, Keys{
-						"roleARN": Equal(fmt.Sprintf("arn:aws-cn:iam::%s:role/the-provider-role", accountID)),
+						"roleARN": Equal(fmt.Sprintf("arn:aws-cn:iam::%s:role/giantswarm-%s-capa-controller", accountID, ManagementClusterName)),
 					}),
 				}),
 			})))

--- a/controllers/crossplane_config_eks_test.go
+++ b/controllers/crossplane_config_eks_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/aws-resolver-rules-operator/controllers"
 )
 
-var _ = Describe("ConfigMapReconcilerEKS", func() {
+var _ = Describe("CrossplaneClusterConfigMapReconcilerEKS", func() {
 	var (
 		ctx context.Context
 
@@ -33,7 +33,7 @@ var _ = Describe("ConfigMapReconcilerEKS", func() {
 		cluster                *capi.Cluster
 
 		request    ctrl.Request
-		reconciler *controllers.ConfigMapReconciler
+		reconciler *controllers.CrossplaneClusterConfigReconciler
 	)
 
 	verifyConfigMap := func() {
@@ -88,7 +88,7 @@ var _ = Describe("ConfigMapReconcilerEKS", func() {
 		ctx = context.Background()
 
 		identity, awsManagedControlplane, cluster = createRandomAwsManagedControlplaneWithIdentity()
-		reconciler = &controllers.ConfigMapReconciler{
+		reconciler = &controllers.CrossplaneClusterConfigReconciler{
 			Client:                k8sClient,
 			BaseDomain:            "base.domain.io",
 			ManagementClusterName: ManagementClusterName,

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	sigs.k8s.io/cluster-api v1.8.3
 	sigs.k8s.io/cluster-api-provider-aws/v2 v2.6.1
 	sigs.k8s.io/controller-runtime v0.19.3
+	sigs.k8s.io/yaml v1.4.0
 )
 
 replace google.golang.org/protobuf v1.31.0 => google.golang.org/protobuf v1.33.0
@@ -87,5 +88,4 @@ require (
 	k8s.io/utils v0.0.0-20240711033017-18e509b52bc8 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect
-	sigs.k8s.io/yaml v1.4.0 // indirect
 )

--- a/helm/aws-resolver-rules-operator/templates/deployment.yaml
+++ b/helm/aws-resolver-rules-operator/templates/deployment.yaml
@@ -55,7 +55,6 @@ spec:
             - --management-cluster-namespace={{ .Values.managementClusterNamespace }}
             - --management-cluster-name={{ .Values.managementClusterName  }}
             - --basedomain={{ .Values.baseDomain }}
-            - --crossplane-provider-role={{ .Values.crossplaneProviderRole }}
             {{- if .Values.disableResolverControllers }}
             - --disable-resolver-controllers
             {{- end }}

--- a/helm/aws-resolver-rules-operator/templates/deployment.yaml
+++ b/helm/aws-resolver-rules-operator/templates/deployment.yaml
@@ -55,6 +55,7 @@ spec:
             - --management-cluster-namespace={{ .Values.managementClusterNamespace }}
             - --management-cluster-name={{ .Values.managementClusterName  }}
             - --basedomain={{ .Values.baseDomain }}
+            - --crossplane-provider-role={{ .Values.crossplaneProviderRole }}
             {{- if .Values.disableResolverControllers }}
             - --disable-resolver-controllers
             {{- end }}

--- a/helm/aws-resolver-rules-operator/templates/rbac.yaml
+++ b/helm/aws-resolver-rules-operator/templates/rbac.yaml
@@ -69,6 +69,19 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - ""
+      - aws.upbound.io
+    resources:
+      - configmaps
+      - providerconfigs
+    verbs:
+      - get
+      - list
+      - create
+      - delete
+      - patch
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/helm/aws-resolver-rules-operator/values.schema.json
+++ b/helm/aws-resolver-rules-operator/values.schema.json
@@ -131,10 +131,6 @@
                     }
                 }
             }
-        },
-        "crossplaneProviderRole": {
-            "type": "string",
-            "description": "The IAM role ARN used by the AWS crossplane provider"
         }
     }
 }

--- a/helm/aws-resolver-rules-operator/values.schema.json
+++ b/helm/aws-resolver-rules-operator/values.schema.json
@@ -33,7 +33,7 @@
                 }
             }
         },
-	"managementClusterName": {
+        "managementClusterName": {
             "type": "string"
         },
         "managementClusterNamespace": {
@@ -103,7 +103,7 @@
                         }
                     }
                 },
-                "capabilities":{
+                "capabilities": {
                     "type": "object",
                     "properties": {
                         "drop": {
@@ -111,7 +111,9 @@
                             "items": {
                                 "type": "string"
                             },
-                            "default": ["ALL"]
+                            "default": [
+                                "ALL"
+                            ]
                         }
                     }
                 }
@@ -129,6 +131,10 @@
                     }
                 }
             }
+        },
+        "crossplaneProviderRole": {
+            "type": "string",
+            "description": "The IAM role ARN used by the AWS crossplane provider"
         }
     }
 }

--- a/main.go
+++ b/main.go
@@ -196,11 +196,11 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err = (&controllers.ConfigMapReconciler{
+	if err = (&controllers.CrossplaneClusterConfigReconciler{
 		Client:                mgr.GetClient(),
 		BaseDomain:            workloadClusterBaseDomain,
 		ManagementClusterName: managementClusterName,
-	}).SetupWithManager(mgr); err != nil {
+	}).SetupWithManager(ctx, mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Frigate")
 		os.Exit(1)
 	}

--- a/main.go
+++ b/main.go
@@ -97,7 +97,6 @@ func main() {
 	var dnsServerVpcId string
 	var managementClusterName string
 	var managementClusterNamespace string
-	var crossplaneProviderRoleARN string
 	var workloadClusterBaseDomain string
 	var syncPeriod time.Duration
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
@@ -115,7 +114,6 @@ func main() {
 	flag.StringVar(&managementClusterName, "management-cluster-name", "", "Management cluster CR name.")
 	flag.StringVar(&managementClusterNamespace, "management-cluster-namespace", "", "Management cluster CR namespace.")
 	flag.StringVar(&workloadClusterBaseDomain, "basedomain", "", "Domain for workload cluster, e.g. installation.eu-west-1.aws.domain.tld")
-	flag.StringVar(&crossplaneProviderRoleARN, "crossplane-provider-role", "", "The role used by the aws crossplane provider.")
 	flag.DurationVar(&syncPeriod, "sync-period", 10*time.Minute, "The minimum interval at which watched resources are reconciled.")
 
 	opts := zap.Options{
@@ -199,9 +197,9 @@ func main() {
 	}
 
 	if err = (&controllers.ConfigMapReconciler{
-		Client:       mgr.GetClient(),
-		BaseDomain:   workloadClusterBaseDomain,
-		ProviderRole: crossplaneProviderRoleARN,
+		Client:                mgr.GetClient(),
+		BaseDomain:            workloadClusterBaseDomain,
+		ManagementClusterName: managementClusterName,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Frigate")
 		os.Exit(1)

--- a/main.go
+++ b/main.go
@@ -97,6 +97,7 @@ func main() {
 	var dnsServerVpcId string
 	var managementClusterName string
 	var managementClusterNamespace string
+	var crossplaneProviderRoleARN string
 	var workloadClusterBaseDomain string
 	var syncPeriod time.Duration
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
@@ -114,6 +115,7 @@ func main() {
 	flag.StringVar(&managementClusterName, "management-cluster-name", "", "Management cluster CR name.")
 	flag.StringVar(&managementClusterNamespace, "management-cluster-namespace", "", "Management cluster CR namespace.")
 	flag.StringVar(&workloadClusterBaseDomain, "basedomain", "", "Domain for workload cluster, e.g. installation.eu-west-1.aws.domain.tld")
+	flag.StringVar(&crossplaneProviderRoleARN, "crossplane-provider-role", "", "The role used by the aws crossplane provider.")
 	flag.DurationVar(&syncPeriod, "sync-period", 10*time.Minute, "The minimum interval at which watched resources are reconciled.")
 
 	opts := zap.Options{
@@ -193,6 +195,15 @@ func main() {
 
 	if err := (controllers.NewKarpenterMachinepoolReconciler(mgr.GetClient(), remote.NewClusterClient, cfg.awsClients)).SetupWithManager(ctx, mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "userdata")
+		os.Exit(1)
+	}
+
+	if err = (&controllers.ConfigMapReconciler{
+		Client:       mgr.GetClient(),
+		BaseDomain:   workloadClusterBaseDomain,
+		ProviderRole: crossplaneProviderRoleARN,
+	}).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "Frigate")
 		os.Exit(1)
 	}
 

--- a/tests/acceptance/fixture/fixture.go
+++ b/tests/acceptance/fixture/fixture.go
@@ -129,27 +129,27 @@ func (f *Fixture) Teardown() error {
 	prefixListID := getARNID(prefixListAnnotation)
 
 	err = DeletePrefixList(f.EC2Client, prefixListID)
-	Expect(err).NotTo(HaveOccurred())
+	Expect(err).To(SatisfyAny(BeNil(), MatchError(ContainSubstring("InvalidPrefixListId.NotFound"))))
 
 	err = DetachTransitGateway(f.EC2Client, gatewayID, f.Network.VpcID)
-	Expect(err).NotTo(HaveOccurred())
+	Expect(err).To(SatisfyAny(BeNil(), MatchError(ContainSubstring("InvalidTransitGatewayID.NotFound"))))
 
 	Eventually(func() error {
 		err := DeleteTransitGateway(f.EC2Client, gatewayID)
 		return err
-	}).Should(Succeed())
+	}).Should(SatisfyAny(BeNil(), MatchError(ContainSubstring("InvalidTransitGatewayID.NotFound"))))
 
 	err = DisassociateRouteTable(f.EC2Client, f.Network.AssociationID)
-	Expect(err).NotTo(HaveOccurred())
+	Expect(err).To(SatisfyAny(BeNil(), MatchError(ContainSubstring("InvalidRouteTableAssociationID.NotFound"))))
 
 	err = DeleteRouteTable(f.EC2Client, f.Network.RouteTableID)
-	Expect(err).NotTo(HaveOccurred())
+	Expect(err).To(SatisfyAny(BeNil(), MatchError(ContainSubstring("InvalidRouteTableID.NotFound"))))
 
 	err = DeleteSubnet(f.EC2Client, f.Network.SubnetID)
-	Expect(err).NotTo(HaveOccurred())
+	Expect(err).To(SatisfyAny(BeNil(), MatchError(ContainSubstring("InvalidSubnetID.NotFound"))))
 
 	err = DeleteVPC(f.EC2Client, f.Network.VpcID)
-	Expect(err).NotTo(HaveOccurred())
+	Expect(err).To(SatisfyAny(BeNil(), MatchError(ContainSubstring("InvalidVpcID.NotFound"))))
 
 	return nil
 }

--- a/tests/common.go
+++ b/tests/common.go
@@ -11,6 +11,8 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	capa "sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
+	eks "sigs.k8s.io/cluster-api-provider-aws/v2/controlplane/eks/api/v1beta2"
+	capi "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -30,6 +32,36 @@ func GetEnvOrSkip(env string) string {
 }
 
 func PatchAWSClusterStatus(k8sClient client.Client, cluster *capa.AWSCluster, status capa.AWSClusterStatus) {
+	patchedCluster := cluster.DeepCopy()
+	patchedCluster.Status = status
+	err := k8sClient.Status().Patch(context.Background(), patchedCluster, client.MergeFrom(cluster))
+	if k8serrors.IsNotFound(err) {
+		return
+	}
+
+	nsName := types.NamespacedName{
+		Name:      cluster.Name,
+		Namespace: cluster.Namespace,
+	}
+	Expect(k8sClient.Get(context.Background(), nsName, cluster)).To(Succeed())
+}
+
+func PatchEKSClusterStatus(k8sClient client.Client, cluster *eks.AWSManagedControlPlane, status eks.AWSManagedControlPlaneStatus) {
+	patchedCluster := cluster.DeepCopy()
+	patchedCluster.Status = status
+	err := k8sClient.Status().Patch(context.Background(), patchedCluster, client.MergeFrom(cluster))
+	if k8serrors.IsNotFound(err) {
+		return
+	}
+
+	nsName := types.NamespacedName{
+		Name:      cluster.Name,
+		Namespace: cluster.Namespace,
+	}
+	Expect(k8sClient.Get(context.Background(), nsName, cluster)).To(Succeed())
+}
+
+func PatchCAPIClusterStatus(k8sClient client.Client, cluster *capi.Cluster, status capi.ClusterStatus) {
 	patchedCluster := cluster.DeepCopy()
 	patchedCluster.Status = status
 	err := k8sClient.Status().Patch(context.Background(), patchedCluster, client.MergeFrom(cluster))

--- a/tests/testdata/crds/aws.upbound.io_providerconfigs.yaml
+++ b/tests/testdata/crds/aws.upbound.io_providerconfigs.yaml
@@ -1,0 +1,484 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  name: providerconfigs.aws.upbound.io
+spec:
+  group: aws.upbound.io
+  names:
+    categories:
+    - crossplane
+    - providerconfig
+    - aws
+    kind: ProviderConfig
+    listKind: ProviderConfigList
+    plural: providerconfigs
+    singular: providerconfig
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: AGE
+      type: date
+    - jsonPath: .spec.source
+      name: SOURCE
+      priority: 1
+      type: string
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: A ProviderConfig configures the AWS provider.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: A ProviderConfigSpec defines the desired state of a ProviderConfig.
+            properties:
+              assumeRoleChain:
+                description: AssumeRoleChain defines the options for assuming an IAM
+                  role
+                items:
+                  description: |-
+                    AssumeRoleOptions define the options for assuming an IAM Role
+                    Fields are similar to the STS AssumeRoleOptions in the AWS SDK
+                  properties:
+                    externalID:
+                      description: ExternalID is the external ID used when assuming
+                        role.
+                      type: string
+                    roleARN:
+                      description: AssumeRoleARN to assume with provider credentials
+                      type: string
+                    tags:
+                      description: |-
+                        Tags is list of session tags that you want to pass. Each session tag consists of a key
+                        name and an associated value. For more information about session tags, see
+                        Tagging STS Sessions
+                        (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_session-tags.html).
+                      items:
+                        description: Tag is session tag that can be used to assume
+                          an IAM Role
+                        properties:
+                          key:
+                            description: |-
+                              Name of the tag.
+                              Key is a required field
+                            type: string
+                          value:
+                            description: |-
+                              Value of the tag.
+                              Value is a required field
+                            type: string
+                        required:
+                        - key
+                        - value
+                        type: object
+                      type: array
+                    transitiveTagKeys:
+                      description: |-
+                        TransitiveTagKeys is a list of keys for session tags that you want to set as transitive. If you set a
+                        tag key as transitive, the corresponding key and value passes to subsequent
+                        sessions in a role chain. For more information, see Chaining Roles with Session Tags
+                        (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_session-tags.html#id_session-tags_role-chaining).
+                      items:
+                        type: string
+                      type: array
+                  type: object
+                type: array
+              credentials:
+                description: Credentials required to authenticate to this provider.
+                properties:
+                  env:
+                    description: |-
+                      Env is a reference to an environment variable that contains credentials
+                      that must be used to connect to the provider.
+                    properties:
+                      name:
+                        description: Name is the name of an environment variable.
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  fs:
+                    description: |-
+                      Fs is a reference to a filesystem location that contains credentials that
+                      must be used to connect to the provider.
+                    properties:
+                      path:
+                        description: Path is a filesystem path.
+                        type: string
+                    required:
+                    - path
+                    type: object
+                  secretRef:
+                    description: |-
+                      A SecretRef is a reference to a secret key that contains the credentials
+                      that must be used to connect to the provider.
+                    properties:
+                      key:
+                        description: The key to select.
+                        type: string
+                      name:
+                        description: Name of the secret.
+                        type: string
+                      namespace:
+                        description: Namespace of the secret.
+                        type: string
+                    required:
+                    - key
+                    - name
+                    - namespace
+                    type: object
+                  source:
+                    description: Source of the provider credentials.
+                    enum:
+                    - None
+                    - Secret
+                    - IRSA
+                    - WebIdentity
+                    - Upbound
+                    type: string
+                  upbound:
+                    description: Upbound defines the options for authenticating using
+                      Upbound as an identity provider.
+                    properties:
+                      webIdentity:
+                        description: |-
+                          WebIdentity defines the options for assuming an IAM role with a Web
+                          Identity.
+                        properties:
+                          roleARN:
+                            description: AssumeRoleARN to assume with provider credentials
+                            type: string
+                          roleSessionName:
+                            description: RoleSessionName is the session name, if you
+                              wish to uniquely identify this session.
+                            type: string
+                          tokenConfig:
+                            description: TokenConfig is the Web Identity Token config
+                              to assume the role.
+                            properties:
+                              fs:
+                                description: |-
+                                  Fs is a reference to a filesystem location that contains credentials that
+                                  must be used to obtain the web identity token.
+                                properties:
+                                  path:
+                                    description: Path is a filesystem path.
+                                    type: string
+                                required:
+                                - path
+                                type: object
+                              secretRef:
+                                description: |-
+                                  A SecretRef is a reference to a secret key that contains the credentials
+                                  that must be used to obtain the web identity token.
+                                properties:
+                                  key:
+                                    description: The key to select.
+                                    type: string
+                                  name:
+                                    description: Name of the secret.
+                                    type: string
+                                  namespace:
+                                    description: Namespace of the secret.
+                                    type: string
+                                required:
+                                - key
+                                - name
+                                - namespace
+                                type: object
+                              source:
+                                description: Source is the source of the web identity
+                                  token.
+                                enum:
+                                - Secret
+                                - Filesystem
+                                type: string
+                            required:
+                            - source
+                            type: object
+                        type: object
+                    type: object
+                  webIdentity:
+                    description: WebIdentity defines the options for assuming an IAM
+                      role with a Web Identity.
+                    properties:
+                      roleARN:
+                        description: AssumeRoleARN to assume with provider credentials
+                        type: string
+                      roleSessionName:
+                        description: RoleSessionName is the session name, if you wish
+                          to uniquely identify this session.
+                        type: string
+                      tokenConfig:
+                        description: TokenConfig is the Web Identity Token config
+                          to assume the role.
+                        properties:
+                          fs:
+                            description: |-
+                              Fs is a reference to a filesystem location that contains credentials that
+                              must be used to obtain the web identity token.
+                            properties:
+                              path:
+                                description: Path is a filesystem path.
+                                type: string
+                            required:
+                            - path
+                            type: object
+                          secretRef:
+                            description: |-
+                              A SecretRef is a reference to a secret key that contains the credentials
+                              that must be used to obtain the web identity token.
+                            properties:
+                              key:
+                                description: The key to select.
+                                type: string
+                              name:
+                                description: Name of the secret.
+                                type: string
+                              namespace:
+                                description: Namespace of the secret.
+                                type: string
+                            required:
+                            - key
+                            - name
+                            - namespace
+                            type: object
+                          source:
+                            description: Source is the source of the web identity
+                              token.
+                            enum:
+                            - Secret
+                            - Filesystem
+                            type: string
+                        required:
+                        - source
+                        type: object
+                    type: object
+                required:
+                - source
+                type: object
+              endpoint:
+                description: |-
+                  Endpoint is where you can override the default endpoint configuration
+                  of AWS calls made by the provider.
+                properties:
+                  hostnameImmutable:
+                    description: |-
+                      Specifies if the endpoint's hostname can be modified by the SDK's API
+                      client.
+
+
+                      If the hostname is mutable the SDK API clients may modify any part of
+                      the hostname based on the requirements of the API, (e.g. adding, or
+                      removing content in the hostname). Such as, Amazon S3 API client
+                      prefixing "bucketname" to the hostname, or changing the
+                      hostname service name component from "s3." to "s3-accesspoint.dualstack."
+                      for the dualstack endpoint of an S3 Accesspoint resource.
+
+
+                      Care should be taken when providing a custom endpoint for an API. If the
+                      endpoint hostname is mutable, and the client cannot modify the endpoint
+                      correctly, the operation call will most likely fail, or have undefined
+                      behavior.
+
+
+                      If hostname is immutable, the SDK API clients will not modify the
+                      hostname of the URL. This may cause the API client not to function
+                      correctly if the API requires the operation specific hostname values
+                      to be used by the client.
+
+
+                      This flag does not modify the API client's behavior if this endpoint
+                      will be used instead of Endpoint Discovery, or if the endpoint will be
+                      used to perform Endpoint Discovery. That behavior is configured via the
+                      API Client's Options.
+                      Note that this is effective only for resources that use AWS SDK v2.
+                    type: boolean
+                  partitionId:
+                    description: The AWS partition the endpoint belongs to.
+                    type: string
+                  services:
+                    description: Specifies the list of services you want endpoint
+                      to be used for
+                    items:
+                      type: string
+                    type: array
+                  signingMethod:
+                    description: |-
+                      The signing method that should be used for signing the requests to the
+                      endpoint.
+                    type: string
+                  signingName:
+                    description: |-
+                      The service name that should be used for signing the requests to the
+                      endpoint.
+                    type: string
+                  signingRegion:
+                    description: |-
+                      The region that should be used for signing the request to the endpoint.
+                      For IAM, which doesn't have any region, us-east-1 is used to sign the
+                      requests, which is the only signing region of IAM.
+                    type: string
+                  source:
+                    description: |-
+                      The source of the Endpoint. By default, this will be ServiceMetadata.
+                      When providing a custom endpoint, you should set the source as Custom.
+                      If source is not provided when providing a custom endpoint, the SDK may not
+                      perform required host mutations correctly. Source should be used along with
+                      HostnameImmutable property as per the usage requirement.
+                      Note that this is effective only for resources that use AWS SDK v2.
+                    enum:
+                    - ServiceMetadata
+                    - Custom
+                    type: string
+                  url:
+                    description: URL lets you configure the endpoint URL to be used
+                      in SDK calls.
+                    properties:
+                      dynamic:
+                        description: Dynamic lets you configure the behavior of endpoint
+                          URL resolver.
+                        properties:
+                          host:
+                            description: |-
+                              Host is the address of the main host that the resolver will use to
+                              prepend protocol, service and region configurations.
+                              For example, the final URL for EC2 in us-east-1 looks like https://ec2.us-east-1.amazonaws.com
+                              You would need to use "amazonaws.com" as Host and "https" as protocol
+                              to have the resolver construct it.
+                            type: string
+                          protocol:
+                            description: |-
+                              Protocol is the HTTP protocol that will be used in the URL. Currently,
+                              only http and https are supported.
+                            enum:
+                            - http
+                            - https
+                            type: string
+                        required:
+                        - host
+                        - protocol
+                        type: object
+                      static:
+                        description: |-
+                          Static is the full URL you'd like the AWS SDK to use.
+                          Recommended for using tools like localstack where a single host is exposed
+                          for all services and regions.
+                        type: string
+                      type:
+                        description: |-
+                          You can provide a static URL that will be used regardless of the service
+                          and region by choosing Static type. Alternatively, you can provide
+                          configuration for dynamically resolving the URL with the config you provide
+                          once you set the type as Dynamic.
+                        enum:
+                        - Static
+                        - Dynamic
+                        type: string
+                    required:
+                    - type
+                    type: object
+                required:
+                - url
+                type: object
+              s3_use_path_style:
+                description: Whether to enable the request to use path-style addressing,
+                  i.e., https://s3.amazonaws.com/BUCKET/KEY.
+                type: boolean
+              skip_credentials_validation:
+                description: |-
+                  Whether to skip credentials validation via the STS API.
+                  This can be useful for testing and for AWS API implementations that do not have STS available.
+                type: boolean
+              skip_metadata_api_check:
+                description: |-
+                  Whether to skip the AWS Metadata API check
+                  Useful for AWS API implementations that do not have a metadata API endpoint.
+                type: boolean
+              skip_region_validation:
+                description: |-
+                  Whether to skip validation of provided region name.
+                  Useful for AWS-like implementations that use their own region names or to bypass the validation for
+                  regions that aren't publicly available yet.
+                type: boolean
+              skip_requesting_account_id:
+                description: |-
+                  Whether to skip requesting the account ID.
+                  Useful for AWS API implementations that do not have the IAM, STS API, or metadata API
+                type: boolean
+            required:
+            - credentials
+            type: object
+          status:
+            description: A ProviderConfigStatus reflects the observed state of a ProviderConfig.
+            properties:
+              conditions:
+                description: Conditions of the resource.
+                items:
+                  description: A Condition that may apply to a resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        LastTransitionTime is the last time this condition transitioned from one
+                        status to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        A Message containing details about this condition's last transition from
+                        one status to another, if any.
+                      type: string
+                    reason:
+                      description: A Reason for this condition's last transition from
+                        one status to another.
+                      type: string
+                    status:
+                      description: Status of this condition; is it currently True,
+                        False, or Unknown?
+                      type: string
+                    type:
+                      description: |-
+                        Type of this condition. At most one of each condition type may apply to
+                        a resource at any point in time.
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              users:
+                description: Users of this provider configuration.
+                format: int64
+                type: integer
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}


### PR DESCRIPTION
### What this PR does / why we need it

This PR copies the code [from this repository](https://github.com/giantswarm/aws-crossplane-cluster-config-operator), so that we combine all our controllers in a single repository. That way we can take care of updating dependencies, fixing vulnerabilities, etc, by only managing this single repository.


### Checklist

- [X] Update changelog in CHANGELOG.md.
