### PR TITLE
Only upgrade to k8s dependencies versions compatible with CAPA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Change `renovate` configuration to only get upgrades for CAPA compatible versions of k8s dependencies.
+
 ## [0.19.0] - 2025-06-17
 
 ### Added

--- a/renovate.json5
+++ b/renovate.json5
@@ -5,4 +5,14 @@
     // Go specific config - https://github.com/giantswarm/renovate-presets/blob/main/lang-go.json5
     "github>giantswarm/renovate-presets:lang-go.json5",
   ],
+  "packageRules": [
+    // Disable kubernetes and controller-runtime dependencies updates, because they will be updated to compatible versions when upgrading CAPA
+    {
+      "matchDepNames": [
+        "/^k8s\\.io\\//",
+        "/^sigs\\.k8s\\.io\\/controller-runtime$/"
+      ],
+      "enabled": false
+    }
+  ]
 }


### PR DESCRIPTION
### What this PR does / why we need it

Currently, we get pull requests for upgrading k8s dependencies whenever there are new releases. But we want to use the same versions that CAPA is using. So in this PR we disable upgrading k8s dependencies, as they will be upgraded whenever CAPA dependency is upgraded.

### Checklist

- [X] Update changelog in CHANGELOG.md.
