### PR TITLE
Disable CAPI dependency upgrades in renovate as they will come when updating CAPA

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -6,11 +6,12 @@
     "github>giantswarm/renovate-presets:lang-go.json5",
   ],
   "packageRules": [
-    // Disable kubernetes and controller-runtime dependencies updates, because they will be updated to compatible versions when upgrading CAPA
+    // Disable kubernetes, controller-runtime and CAPI dependencies updates, because they will be updated to compatible versions when upgrading CAPA
     {
       "matchDepNames": [
         "/^k8s\\.io\\//",
-        "/^sigs\\.k8s\\.io\\/controller-runtime$/"
+        "/^sigs\\.k8s\\.io\\/controller-runtime$/",
+        "/^sigs\\.k8s\\.io\\/cluster-api$/"
       ],
       "enabled": false
     }


### PR DESCRIPTION
### What this PR does / why we need it


### Checklist

- [ ] Update changelog in CHANGELOG.md.
