### PR TITLE
Reduce sync period to 2m

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Change controllers sync period to 2 minutes.
+
 ## [0.21.0] - 2025-09-02
 
 ### Changed

--- a/main.go
+++ b/main.go
@@ -114,7 +114,7 @@ func main() {
 	flag.StringVar(&managementClusterName, "management-cluster-name", "", "Management cluster CR name.")
 	flag.StringVar(&managementClusterNamespace, "management-cluster-namespace", "", "Management cluster CR namespace.")
 	flag.StringVar(&workloadClusterBaseDomain, "basedomain", "", "Domain for workload cluster, e.g. installation.eu-west-1.aws.domain.tld")
-	flag.DurationVar(&syncPeriod, "sync-period", 10*time.Minute, "The minimum interval at which watched resources are reconciled.")
+	flag.DurationVar(&syncPeriod, "sync-period", 2*time.Minute, "The minimum interval at which watched resources are reconciled.")
 
 	opts := zap.Options{
 		Development: false,


### PR DESCRIPTION
### What this PR does / why we need it

This change makes the whole operator (all controllers inside the operator, not just karpenter) reconcile all CRs every 2m, instead of every 10m.
We need this because there is a taint in the worker nodes that is only removed when the `KarpenterMachinePool` is reconciled. Without this change, it takes many minutes for the controller to remove the taint. With this change, it takes 2m tops.

### Checklist

- [X] Update changelog in CHANGELOG.md.
