### PR TITLE
Update Localstack to 4.8.1

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,10 +3,10 @@ version: "3.8"
 services:
   localstack:
     container_name: "${LOCALSTACK_DOCKER_NAME-localstack-main}"
-    image: quay.io/giantswarm/localstack:v2.2.0-gsdev2
+    image: quay.io/giantswarm/localstack:v4.8.1
     ports:
-      - "127.0.0.1:4566:4566"            # LocalStack Gateway
-      - "127.0.0.1:4510-4559:4510-4559"  # external services port range
+      - "127.0.0.1:4566:4566" # LocalStack Gateway
+      - "127.0.0.1:4510-4559:4510-4559" # external services port range
     environment:
       - DEBUG=1
       - DOCKER_HOST=unix:///var/run/docker.sock


### PR DESCRIPTION
### What this PR does / why we need it

Localstack was added to retagger since this morning. Not sure why Renovate is not generating a PR, but let's bump it manually for now.

### Checklist

- [ ] Update changelog in CHANGELOG.md.
