### PR TITLE
Termination grace period

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Use OpenTelemetry for metrics.
 - Disable `controller-runtime` cache for `ConfigMaps` to decrease memory usage.
 
+### Added
+
+- Add a terminationGracePeriod of 30 minutes by default.
+
 ## [0.22.0] - 2025-09-10
 
 ### Changed

--- a/controllers/karpentermachinepool_controller.go
+++ b/controllers/karpentermachinepool_controller.go
@@ -580,6 +580,8 @@ func (r *KarpenterMachinePoolReconciler) createOrUpdateNodePool(ctx context.Cont
 
 			if karpenterMachinePool.Spec.NodePool.Template.Spec.TerminationGracePeriod != nil {
 				templateSpec["terminationGracePeriod"] = karpenterMachinePool.Spec.NodePool.Template.Spec.TerminationGracePeriod
+			} else {
+				templateSpec["terminationGracePeriod"] = "30m"
 			}
 		}
 


### PR DESCRIPTION
### What this PR does / why we need it

Set a default termination grace period that can be updated by the customer (this is still not exposed in clusterAWS but should work as soon as its available)

### Checklist

- [x] Update changelog in CHANGELOG.md.
