### PR TITLE
[DO NOT MERGE until all clusters got upgraded] Allow to configure the systemReserved and kubeReserved kubelet settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Use configurable kubelet `systemReserved` and `kubeReserved` settings from `KarpenterMachinePool.Spec.EC2NodeClass.Kubelet` instead of hardcoded values.
+
 ## [0.25.1] - 2026-01-21
 
 ### Changed

--- a/controllers/karpentermachinepool_controller.go
+++ b/controllers/karpentermachinepool_controller.go
@@ -480,17 +480,10 @@ func (r *KarpenterMachinePoolReconciler) createOrUpdateEC2NodeClass(ctx context.
 			"subnetSelectorTerms":        karpenterMachinePool.Spec.EC2NodeClass.SubnetSelectorTerms,
 			"userData":                   userData,
 			"tags":                       mergeMaps(awsCluster.Spec.AdditionalTags, karpenterMachinePool.Spec.EC2NodeClass.Tags),
-			"kubelet": map[string]interface{}{
-				"systemReserved": map[string]string{
-					"cpu":    "250m",
-					"memory": "384Mi",
-				},
-				"kubeReserved": map[string]string{
-					"cpu":               "350m",
-					"memory":            "1280Mi",
-					"ephemeral-storage": "1024Mi",
-				},
-			},
+		}
+
+		if karpenterMachinePool.Spec.EC2NodeClass.Kubelet != nil {
+			spec["kubelet"] = karpenterMachinePool.Spec.EC2NodeClass.Kubelet
 		}
 
 		ec2NodeClass.Object["spec"] = spec

--- a/controllers/karpentermachinepool_controller_test.go
+++ b/controllers/karpentermachinepool_controller_test.go
@@ -601,6 +601,16 @@ var _ = Describe("KarpenterMachinePool reconciler", func() {
 							Tags: map[string]string{
 								"one-tag": "only-for-karpenter",
 							},
+							Kubelet: &karpenterinfra.KubeletConfiguration{
+								SystemReserved: map[string]string{
+									"cpu":    "100m",
+									"memory": "256Mi",
+								},
+								KubeReserved: map[string]string{
+									"cpu":    "200m",
+									"memory": "512Mi",
+								},
+							},
 						},
 						NodePool: &karpenterinfra.NodePoolSpec{
 							Template: karpenterinfra.NodeClaimTemplate{
@@ -973,13 +983,12 @@ var _ = Describe("KarpenterMachinePool reconciler", func() {
 								ExpectUnstructured(ec2nodeclassList.Items[0], "spec", "kubelet").To(
 									gstruct.MatchAllKeys(gstruct.Keys{
 										"systemReserved": gstruct.MatchAllKeys(gstruct.Keys{
-											"cpu":    Equal("250m"),
-											"memory": Equal("384Mi"),
+											"cpu":    Equal("100m"),
+											"memory": Equal("256Mi"),
 										}),
 										"kubeReserved": gstruct.MatchAllKeys(gstruct.Keys{
-											"cpu":               Equal("350m"),
-											"memory":            Equal("1280Mi"),
-											"ephemeral-storage": Equal("1024Mi"),
+											"cpu":    Equal("200m"),
+											"memory": Equal("512Mi"),
 										}),
 									}),
 								)


### PR DESCRIPTION
### What this PR does / why we need it

Allow to configure the systemReserved and kubeReserved kubelet settings.

To avoid potential issues related to these settings, we should wait to release this change until all karpenter users upgrade to a GS release containing this change https://github.com/giantswarm/cluster-aws/pull/1722 (updated: it's v34.1.0)

### Checklist

- [x] Update changelog in CHANGELOG.md.
