### PR TITLE
Fix wildcard DNS record creation for AWS China regions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Skip IRSA DNS record check for AWS China regions (`cn-*`) when creating wildcard DNS records. China regions do not use IRSA, so waiting for the IRSA record would block wildcard creation indefinitely.
+
 ## [0.26.0] - 2026-03-11
 
 ### Added
@@ -19,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Skip creating the wildcard DNS record when the `irsa` DNS record does not exist in the cluster's Route53 hosted zone (indicating IRSA is not yet ready).
+- Skip creating the wildcard DNS record when the `IRSA` DNS record does not exist in the cluster's Route53 hosted zone (indicating IRSA is not yet ready).
 - Add warning if static AWS credentials aren't used, falling back to the deprecated IRSA code path
 
 ### Removed

--- a/controllers/dns_test.go
+++ b/controllers/dns_test.go
@@ -332,6 +332,25 @@ var _ = Describe("Dns Zone reconciler", func() {
 						})
 					})
 
+					When("the cluster is in an AWS China region", func() {
+						BeforeEach(func() {
+							awsCluster.Spec.Region = "cn-north-1"
+							awsCluster.Spec.ControlPlaneEndpoint.Host = ControlPlaneEndpointHost
+							route53Client.DnsRecordExistsReturns(false, nil)
+							route53Client.GetHostedZoneIdByNameReturns("parent-hosted-zone-id", nil)
+							route53Client.CreateHostedZoneReturns("hosted-zone-id", nil)
+						})
+
+						It("creates the wildcard DNS record without waiting for IRSA", func() {
+							_, _, _, dnsRecords := route53Client.AddDnsRecordsToHostedZoneArgsForCall(0)
+							Expect(dnsRecords).To(ContainElements(resolver.DNSRecord{
+								Kind:   resolver.DnsRecordTypeCname,
+								Name:   fmt.Sprintf("*.%s.%s", ClusterName, WorkloadClusterBaseDomain),
+								Values: []string{fmt.Sprintf("ingress.%s.%s", ClusterName, WorkloadClusterBaseDomain)},
+							}))
+						})
+					})
+
 					When("the cluster uses public dns mode", func() {
 						BeforeEach(func() {
 							route53Client.GetHostedZoneIdByNameReturns("parent-hosted-zone-id", nil)

--- a/pkg/resolver/zoner.go
+++ b/pkg/resolver/zoner.go
@@ -247,7 +247,7 @@ func (d *Zoner) getWorkloadClusterDnsRecords(ctx context.Context, logger logr.Lo
 	var dnsRecords []DNSRecord
 	var createWildcardRecord bool
 
-	if !cluster.IsEKS {
+	if !cluster.IsEKS && !isAWSChinaRegion(cluster.Region) {
 		irsaRecordName := fmt.Sprintf("irsa.%s", workloadClusterHostedZoneName)
 		var err error
 		createWildcardRecord, err = route53Client.DnsRecordExists(ctx, logger, hostedZoneId, irsaRecordName)
@@ -255,7 +255,9 @@ func (d *Zoner) getWorkloadClusterDnsRecords(ctx context.Context, logger logr.Lo
 			return nil, errors.WithStack(err)
 		}
 	} else {
-		// For EKS clusters we can assume IRSA is ready from the start, so we can create the wildcard record immediately
+		// For EKS clusters and AWS China regions we can create the wildcard record immediately.
+		// EKS has IRSA ready from the start. China regions (cn-*) do not use IRSA at all,
+		// so waiting for an irsa DNS record would block wildcard creation indefinitely.
 		createWildcardRecord = true
 	}
 
@@ -291,4 +293,9 @@ func (d *Zoner) getWorkloadClusterDnsRecords(ctx context.Context, logger logr.Lo
 	}
 
 	return dnsRecords, nil
+}
+
+// isAWSChinaRegion returns true for AWS China partition regions (cn-north-1, cn-northwest-1).
+func isAWSChinaRegion(region string) bool {
+	return strings.HasPrefix(region, "cn-")
 }

--- a/pkg/resolver/zoner.go
+++ b/pkg/resolver/zoner.go
@@ -256,7 +256,7 @@ func (d *Zoner) getWorkloadClusterDnsRecords(ctx context.Context, logger logr.Lo
 		}
 	} else {
 		// For EKS clusters and AWS China regions we can create the wildcard record immediately.
-		// EKS has IRSA ready from the start. China regions (cn-*) do not use IRSA at all,
+		// EKS has IRSA ready from the start. China regions (cn-*) do not use CloudFront, they don't have an IRSA dns record,
 		// so waiting for an irsa DNS record would block wildcard creation indefinitely.
 		createWildcardRecord = true
 	}


### PR DESCRIPTION
Towards https://gigantic.slack.com/archives/C0561JVB0HY/p1773465823208029

The IRSA readiness check introduced in v0.26.0 (#407) blocks wildcard DNS record (`*.<zone>`) creation indefinitely on AWS China clusters because China regions do not use IRSA — the `irsa.<zone>` DNS record will never exist.

This skips the IRSA check for China regions (`cn-*`), creating the wildcard record immediately, same as EKS clusters.