### PR TITLE
Gate KarpenterMachinePool finalizer removal on AWS-side state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - KarpenterMachinePool finalizer removal is now gated on AWS-side state. The controller keeps the finalizer in place until `DescribeInstances` reports zero non-terminated EC2 instances matching both the pool's `karpenter.sh/nodepool` value and the parent cluster's `giantswarm.io/cluster` tag, instead of relying on the parent Cluster's deletionTimestamp being visible in the local informer cache. This fixes a race where, during `helm uninstall` of the cluster-aws chart, the Cluster's deletionTimestamp had not yet propagated when the KarpenterMachinePool delete reconcile ran, the controller skipped EC2 termination entirely, and the Karpenter-provisioned nodes were left running. The orphan ENIs then blocked CAPA from deleting the cluster's security groups and node subnets indefinitely.
-- The EC2 lookup is now scoped by cluster as well as NodePool name, so two clusters that happen to use the same NodePool name cannot cause a KarpenterMachinePool delete reconcile in one cluster to terminate (or wait on) instances belonging to the other.
 - `GetNonTerminatedInstancesByTags` now paginates `DescribeInstances` (using `NewDescribeInstancesPaginator`) instead of reading only the first page, and guards against a nil `instance.State` from the AWS SDK before dereferencing it.
 - Failures to delete the Karpenter `NodePool`/`EC2NodeClass` in the workload cluster are now propagated (instead of silently swallowed) when the parent Cluster is still alive, so transient workload-cluster API errors trigger a normal controller-runtime retry. The error is still tolerated when the parent Cluster is being deleted, where the workload cluster may legitimately be unreachable.
-
-### Changed
-
-- The `EC2Client` interface now exposes `GetNonTerminatedInstancesByTags` (accepting an arbitrary set of tag key/value filters that are ANDed by the EC2 API) and `TerminateInstances` in place of the single-call `TerminateInstancesByTag`. The new split lets callers gate finalizer removal on AWS-side state independently of issuing termination, which is necessary while in-cluster Karpenter (the rightful drainer) is still alive.
 
 ## [0.26.1] - 2026-03-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - KarpenterMachinePool finalizer removal is now gated on AWS-side state. The controller keeps the finalizer in place until `DescribeInstances` reports zero non-terminated EC2 instances matching both the pool's `karpenter.sh/nodepool` value and the parent cluster's `giantswarm.io/cluster` tag, instead of relying on the parent Cluster's deletionTimestamp being visible in the local informer cache. This fixes a race where, during `helm uninstall` of the cluster-aws chart, the Cluster's deletionTimestamp had not yet propagated when the KarpenterMachinePool delete reconcile ran, the controller skipped EC2 termination entirely, and the Karpenter-provisioned nodes were left running. The orphan ENIs then blocked CAPA from deleting the cluster's security groups and node subnets indefinitely.
 - The EC2 lookup is now scoped by cluster as well as NodePool name, so two clusters that happen to use the same NodePool name cannot cause a KarpenterMachinePool delete reconcile in one cluster to terminate (or wait on) instances belonging to the other.
+- `GetNonTerminatedInstancesByTags` now paginates `DescribeInstances` (using `NewDescribeInstancesPaginator`) instead of reading only the first page, and guards against a nil `instance.State` from the AWS SDK before dereferencing it.
+- Failures to delete the Karpenter `NodePool`/`EC2NodeClass` in the workload cluster are now propagated (instead of silently swallowed) when the parent Cluster is still alive, so transient workload-cluster API errors trigger a normal controller-runtime retry. The error is still tolerated when the parent Cluster is being deleted, where the workload cluster may legitimately be unreachable.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- KarpenterMachinePool finalizer removal is now gated on AWS-side state. The controller keeps the finalizer in place until `DescribeInstances` reports zero non-terminated EC2 instances tagged with the pool's `karpenter.sh/nodepool` value, instead of relying on the parent Cluster's deletionTimestamp being visible in the local informer cache. This fixes a race where, during `helm uninstall` of the cluster-aws chart, the Cluster's deletionTimestamp had not yet propagated when the KarpenterMachinePool delete reconcile ran, the controller skipped EC2 termination entirely, and the Karpenter-provisioned nodes were left running. The orphan ENIs then blocked CAPA from deleting the cluster's security groups and node subnets indefinitely.
+- KarpenterMachinePool finalizer removal is now gated on AWS-side state. The controller keeps the finalizer in place until `DescribeInstances` reports zero non-terminated EC2 instances matching both the pool's `karpenter.sh/nodepool` value and the parent cluster's `giantswarm.io/cluster` tag, instead of relying on the parent Cluster's deletionTimestamp being visible in the local informer cache. This fixes a race where, during `helm uninstall` of the cluster-aws chart, the Cluster's deletionTimestamp had not yet propagated when the KarpenterMachinePool delete reconcile ran, the controller skipped EC2 termination entirely, and the Karpenter-provisioned nodes were left running. The orphan ENIs then blocked CAPA from deleting the cluster's security groups and node subnets indefinitely.
+- The EC2 lookup is now scoped by cluster as well as NodePool name, so two clusters that happen to use the same NodePool name cannot cause a KarpenterMachinePool delete reconcile in one cluster to terminate (or wait on) instances belonging to the other.
 
 ### Changed
 
-- The `EC2Client` interface now exposes `GetNonTerminatedInstancesByTag` and `TerminateInstances` in place of the single-call `TerminateInstancesByTag`. The new split lets callers gate finalizer removal on AWS-side state independently of issuing termination, which is necessary while in-cluster Karpenter (the rightful drainer) is still alive.
+- The `EC2Client` interface now exposes `GetNonTerminatedInstancesByTags` (accepting an arbitrary set of tag key/value filters that are ANDed by the EC2 API) and `TerminateInstances` in place of the single-call `TerminateInstancesByTag`. The new split lets callers gate finalizer removal on AWS-side state independently of issuing termination, which is necessary while in-cluster Karpenter (the rightful drainer) is still alive.
 
 ## [0.26.1] - 2026-03-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- KarpenterMachinePool finalizer removal is now gated on AWS-side state. The controller keeps the finalizer in place until `DescribeInstances` reports zero non-terminated EC2 instances tagged with the pool's `karpenter.sh/nodepool` value, instead of relying on the parent Cluster's deletionTimestamp being visible in the local informer cache. This fixes a race where, during `helm uninstall` of the cluster-aws chart, the Cluster's deletionTimestamp had not yet propagated when the KarpenterMachinePool delete reconcile ran, the controller skipped EC2 termination entirely, and the Karpenter-provisioned nodes were left running. The orphan ENIs then blocked CAPA from deleting the cluster's security groups and node subnets indefinitely.
+
+### Changed
+
+- The `EC2Client` interface now exposes `GetNonTerminatedInstancesByTag` and `TerminateInstances` in place of the single-call `TerminateInstancesByTag`. The new split lets callers gate finalizer removal on AWS-side state independently of issuing termination, which is necessary while in-cluster Karpenter (the rightful drainer) is still alive.
+
 ## [0.26.1] - 2026-03-16
 
 ### Fixed

--- a/controllers/karpentermachinepool_controller.go
+++ b/controllers/karpentermachinepool_controller.go
@@ -305,36 +305,52 @@ func (r *KarpenterMachinePoolReconciler) reconcileMachinePoolBootstrapUserData(c
 	return nil
 }
 
-// reconcileDelete deletes the karpenter custom resources from the workload cluster.
-// When the cluster itself is being deleted, it also terminates all EC2 instances
-// created by Karpenter to prevent orphaned resources.
+// reconcileDelete drives the deletion of a KarpenterMachinePool, ensuring that no
+// Karpenter-provisioned EC2 instance is orphaned before the finalizer is removed.
+//
+// Finalizer removal is gated on AWS-side state: while any non-terminated EC2 instance
+// tagged `karpenter.sh/nodepool=<KMP-name>` exists, the finalizer stays in place. This
+// avoids a previously observed leak in which the parent Cluster's deletionTimestamp
+// had not yet propagated to the controller's informer cache by the time the KMP delete
+// reconcile ran. In that race the controller used to skip both EC2 termination and the
+// finalizer-protecting wait, and the instances were left running after the cluster was
+// torn down (CAPA then looped forever on DependencyViolation deleting SGs/subnets).
+//
+// While the parent Cluster is still alive the in-WC Karpenter is the rightful drainer
+// (PDBs, graceful eviction); the controller deletes its NodePool/EC2NodeClass to signal
+// disruption and polls until Karpenter has terminated the instances. Once the parent
+// Cluster is being deleted the in-WC Karpenter is going away with it, so the controller
+// terminates the remaining instances directly.
 func (r *KarpenterMachinePoolReconciler) reconcileDelete(ctx context.Context, logger logr.Logger, cluster *capi.Cluster, awsCluster *capa.AWSCluster, karpenterMachinePool *v1alpha1.KarpenterMachinePool, roleIdentity *capa.AWSClusterRoleIdentity, patchHelper *patch.Helper) (reconcile.Result, error) {
-	// We check if the owner Cluster is also being deleted (on top of the `KarpenterMachinePool` being deleted).
-	// If the Cluster is being deleted, we terminate all the ec2 instances that karpenter may have launched.
-	// These are normally removed by Karpenter, but when deleting a cluster, karpenter may not have enough time to clean them up.
-	if !cluster.GetDeletionTimestamp().IsZero() {
-		ec2Client, err := r.awsClients.NewEC2Client(awsCluster.Spec.Region, roleIdentity.Spec.RoleArn)
-		if err != nil {
-			return reconcile.Result{}, fmt.Errorf("failed to create EC2 client: %w", err)
-		}
-
-		// Terminate EC2 instances with the karpenter.sh/nodepool tag matching the KarpenterMachinePool name
-		instanceIDs, err := ec2Client.TerminateInstancesByTag(ctx, logger, "karpenter.sh/nodepool", karpenterMachinePool.Name)
-		if err != nil {
-			return reconcile.Result{}, fmt.Errorf("failed to terminate EC2 instances: %w", err)
-		}
-
-		// Requeue if we find instances to terminate. On the next reconciliation, once there are no instances to terminate, we proceed to remove the finalizer.
-		// We don't want to remove the finalizer when there may be ec2 instances still around to be cleaned up.
-		if len(instanceIDs) > 0 {
-			return reconcile.Result{RequeueAfter: 30 * time.Second}, nil
-		}
+	ec2Client, err := r.awsClients.NewEC2Client(awsCluster.Spec.Region, roleIdentity.Spec.RoleArn)
+	if err != nil {
+		return reconcile.Result{}, fmt.Errorf("failed to create EC2 client: %w", err)
 	}
 
-	// Delete Karpenter resources from the workload cluster
+	// Delete the Karpenter NodePool/EC2NodeClass in the workload cluster so the in-WC
+	// Karpenter starts disrupting NodeClaims for this pool. Best-effort: if the workload
+	// cluster has already been torn down the client lookup will fail and we still proceed
+	// to clean up EC2 directly below.
 	if err := r.deleteKarpenterResources(ctx, logger, cluster, karpenterMachinePool); err != nil {
-		logger.Error(err, "failed to delete Karpenter resources")
-		return reconcile.Result{}, err
+		logger.Error(err, "failed to delete Karpenter resources in workload cluster; continuing with EC2-side cleanup")
+	}
+
+	// Authoritative AWS-side check that gates finalizer removal.
+	instanceIDs, err := ec2Client.GetNonTerminatedInstancesByTag(ctx, logger, "karpenter.sh/nodepool", karpenterMachinePool.Name)
+	if err != nil {
+		return reconcile.Result{}, fmt.Errorf("failed to list EC2 instances: %w", err)
+	}
+
+	if len(instanceIDs) > 0 {
+		if !cluster.GetDeletionTimestamp().IsZero() {
+			logger.Info("Cluster is being deleted; terminating remaining EC2 instances", "count", len(instanceIDs), "instances", instanceIDs)
+			if err := ec2Client.TerminateInstances(ctx, logger, instanceIDs); err != nil {
+				return reconcile.Result{}, fmt.Errorf("failed to terminate EC2 instances: %w", err)
+			}
+		} else {
+			logger.Info("Cluster is still alive; waiting for Karpenter to terminate EC2 instances", "count", len(instanceIDs), "instances", instanceIDs)
+		}
+		return reconcile.Result{RequeueAfter: 30 * time.Second}, nil
 	}
 
 	logger.Info("Removing finalizer", "finalizer", KarpenterFinalizer)

--- a/controllers/karpentermachinepool_controller.go
+++ b/controllers/karpentermachinepool_controller.go
@@ -341,14 +341,7 @@ func (r *KarpenterMachinePoolReconciler) reconcileDelete(ctx context.Context, lo
 		logger.Error(err, "failed to delete Karpenter resources in workload cluster; cluster is being deleted, continuing with EC2-side cleanup")
 	}
 
-	// Authoritative AWS-side check that gates finalizer removal. We scope the match by
-	// BOTH pool identity and cluster ownership so that two clusters using the same
-	// NodePool name (e.g. both have a pool named "default") cannot cause this reconcile
-	// to touch instances belonging to the other cluster. The `giantswarm.io/cluster`
-	// tag is propagated to every Karpenter-provisioned instance via the EC2NodeClass
-	// tags built by `createOrUpdateEC2NodeClass`, sourced from
-	// `awsCluster.Spec.AdditionalTags` (populated by the cluster-aws Helm chart at
-	// `helm/cluster-aws/templates/_aws_cluster.tpl`).
+	// Authoritative AWS-side check that gates finalizer removal.
 	instanceIDs, err := ec2Client.GetNonTerminatedInstancesByTags(ctx, logger, map[string]string{
 		"karpenter.sh/nodepool": karpenterMachinePool.Name,
 		"giantswarm.io/cluster": cluster.Name,

--- a/controllers/karpentermachinepool_controller.go
+++ b/controllers/karpentermachinepool_controller.go
@@ -335,8 +335,16 @@ func (r *KarpenterMachinePoolReconciler) reconcileDelete(ctx context.Context, lo
 		logger.Error(err, "failed to delete Karpenter resources in workload cluster; continuing with EC2-side cleanup")
 	}
 
-	// Authoritative AWS-side check that gates finalizer removal.
-	instanceIDs, err := ec2Client.GetNonTerminatedInstancesByTag(ctx, logger, "karpenter.sh/nodepool", karpenterMachinePool.Name)
+	// Authoritative AWS-side check that gates finalizer removal. We scope the match by
+	// BOTH pool identity and cluster ownership so that two clusters using the same
+	// NodePool name (e.g. both have a pool named "default") cannot cause this reconcile
+	// to touch instances belonging to the other cluster. The `giantswarm.io/cluster`
+	// tag is set on every Karpenter-provisioned instance via
+	// `awsCluster.Spec.AdditionalTags` -> EC2NodeClass tags by this same controller.
+	instanceIDs, err := ec2Client.GetNonTerminatedInstancesByTags(ctx, logger, map[string]string{
+		"karpenter.sh/nodepool": karpenterMachinePool.Name,
+		"giantswarm.io/cluster": cluster.Name,
+	})
 	if err != nil {
 		return reconcile.Result{}, fmt.Errorf("failed to list EC2 instances: %w", err)
 	}

--- a/controllers/karpentermachinepool_controller.go
+++ b/controllers/karpentermachinepool_controller.go
@@ -328,19 +328,27 @@ func (r *KarpenterMachinePoolReconciler) reconcileDelete(ctx context.Context, lo
 	}
 
 	// Delete the Karpenter NodePool/EC2NodeClass in the workload cluster so the in-WC
-	// Karpenter starts disrupting NodeClaims for this pool. Best-effort: if the workload
-	// cluster has already been torn down the client lookup will fail and we still proceed
-	// to clean up EC2 directly below.
+	// Karpenter starts disrupting NodeClaims for this pool. While the parent Cluster
+	// is alive the workload-cluster API is expected to be reachable, so a failure here
+	// is treated as a real error and propagated; controller-runtime will requeue with
+	// backoff. Once the parent Cluster is being deleted the workload cluster may
+	// already be torn down (kubeconfig secret gone, control plane removed), so we
+	// tolerate the failure and proceed to clean up EC2 directly.
 	if err := r.deleteKarpenterResources(ctx, logger, cluster, karpenterMachinePool); err != nil {
-		logger.Error(err, "failed to delete Karpenter resources in workload cluster; continuing with EC2-side cleanup")
+		if cluster.GetDeletionTimestamp().IsZero() {
+			return reconcile.Result{}, fmt.Errorf("failed to delete Karpenter resources in workload cluster: %w", err)
+		}
+		logger.Error(err, "failed to delete Karpenter resources in workload cluster; cluster is being deleted, continuing with EC2-side cleanup")
 	}
 
 	// Authoritative AWS-side check that gates finalizer removal. We scope the match by
 	// BOTH pool identity and cluster ownership so that two clusters using the same
 	// NodePool name (e.g. both have a pool named "default") cannot cause this reconcile
 	// to touch instances belonging to the other cluster. The `giantswarm.io/cluster`
-	// tag is set on every Karpenter-provisioned instance via
-	// `awsCluster.Spec.AdditionalTags` -> EC2NodeClass tags by this same controller.
+	// tag is propagated to every Karpenter-provisioned instance via the EC2NodeClass
+	// tags built by `createOrUpdateEC2NodeClass`, sourced from
+	// `awsCluster.Spec.AdditionalTags` (populated by the cluster-aws Helm chart at
+	// `helm/cluster-aws/templates/_aws_cluster.tpl`).
 	instanceIDs, err := ec2Client.GetNonTerminatedInstancesByTags(ctx, logger, map[string]string{
 		"karpenter.sh/nodepool": karpenterMachinePool.Name,
 		"giantswarm.io/cluster": cluster.Name,

--- a/controllers/karpentermachinepool_controller_test.go
+++ b/controllers/karpentermachinepool_controller_test.go
@@ -240,6 +240,14 @@ var _ = Describe("KarpenterMachinePool reconciler", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
+		// AWSClusterRoleIdentity is cluster-scoped, so it survives the per-spec namespace
+		// teardown. Clean it up here to avoid AlreadyExists collisions between specs in
+		// this `When` block.
+		AfterEach(func() {
+			roleIdentity := &capa.AWSClusterRoleIdentity{ObjectMeta: metav1.ObjectMeta{Name: "default-delete-test"}}
+			_ = k8sClient.Delete(ctx, roleIdentity)
+		})
+
 		When("the owner cluster is also being deleted", func() {
 			BeforeEach(func() {
 				kubeadmControlPlane := &unstructured.Unstructured{}
@@ -300,18 +308,22 @@ var _ = Describe("KarpenterMachinePool reconciler", func() {
 				Expect(err).NotTo(HaveOccurred())
 			})
 			// This test is a bit cumbersome because we are deleting CRs, so we can't use different `It` blocks or the CRs would be gone.
-			// We first mock the call to `TerminateInstancesByTag` to return some instances so that we can test
+			// We first mock the call to `GetNonTerminatedInstancesByTag` to return some instances so that we can test
 			// the behavior when there are pending instances to remove.
 			// Then we manually/explicitly call the reconciler inside the test again, to be able to test the behavior
 			// when there are no instances to remove.
 			When("there are ec2 instances from karpenter", func() {
 				BeforeEach(func() {
-					ec2Client.TerminateInstancesByTagReturnsOnCall(0, []string{"i-abc123", "i-def456"}, nil)
+					ec2Client.GetNonTerminatedInstancesByTagReturnsOnCall(0, []string{"i-abc123", "i-def456"}, nil)
 				})
 
-				It("deletes KarpenterMachinePool ec2 instances and finalizer", func() {
+				It("terminates ec2 instances, keeps the finalizer until AWS is clean, and only then removes it", func() {
+					// First reconcile: instances still present, controller terminates them and requeues.
 					Expect(reconcileErr).NotTo(HaveOccurred())
-					Expect(ec2Client.TerminateInstancesByTagCallCount()).To(Equal(1))
+					Expect(ec2Client.GetNonTerminatedInstancesByTagCallCount()).To(Equal(1))
+					Expect(ec2Client.TerminateInstancesCallCount()).To(Equal(1))
+					_, _, terminatedIDs := ec2Client.TerminateInstancesArgsForCall(0)
+					Expect(terminatedIDs).To(ConsistOf("i-abc123", "i-def456"))
 					Expect(reconcileResult.RequeueAfter).To(Equal(30 * time.Second))
 
 					karpenterMachinePoolList := &karpenterinfra.KarpenterMachinePoolList{}
@@ -320,7 +332,8 @@ var _ = Describe("KarpenterMachinePool reconciler", func() {
 					// Finalizer should be there blocking the deletion of the CR
 					Expect(karpenterMachinePoolList.Items).To(HaveLen(1))
 
-					ec2Client.TerminateInstancesByTagReturnsOnCall(0, nil, nil)
+					// Second reconcile: AWS reports zero non-terminated instances, controller removes the finalizer.
+					ec2Client.GetNonTerminatedInstancesByTagReturnsOnCall(1, nil, nil)
 
 					reconcileResult, reconcileErr = reconciler.Reconcile(ctx, ctrl.Request{
 						NamespacedName: types.NamespacedName{
@@ -329,10 +342,81 @@ var _ = Describe("KarpenterMachinePool reconciler", func() {
 						},
 					})
 
+					Expect(ec2Client.GetNonTerminatedInstancesByTagCallCount()).To(Equal(2))
+					// TerminateInstances was not called again because the list was empty.
+					Expect(ec2Client.TerminateInstancesCallCount()).To(Equal(1))
+
 					karpenterMachinePoolList = &karpenterinfra.KarpenterMachinePoolList{}
 					err = k8sClient.List(ctx, karpenterMachinePoolList, client.InNamespace(namespace))
 					Expect(err).NotTo(HaveOccurred())
 					// Finalizer should've been removed and the CR should be gone
+					Expect(karpenterMachinePoolList.Items).To(HaveLen(0))
+				})
+			})
+		})
+
+		// This covers the previously-leaking case: the KarpenterMachinePool is being
+		// deleted but the parent Cluster is still alive (e.g., the user removed only
+		// the node pool, or the Cluster's deletionTimestamp has not yet propagated to
+		// the controller's informer cache during a helm uninstall). The controller
+		// must defer EC2 termination to in-WC Karpenter while keeping the finalizer
+		// in place until AWS confirms zero matching instances.
+		When("the owner cluster is not being deleted", func() {
+			BeforeEach(func() {
+				cluster := &capi.Cluster{
+					ObjectMeta: ctrl.ObjectMeta{
+						Namespace: namespace,
+						Name:      ClusterName,
+						Labels: map[string]string{
+							capi.ClusterNameLabel: ClusterName,
+						},
+					},
+					Spec: capi.ClusterSpec{
+						InfrastructureRef: &v1.ObjectReference{
+							Kind:       "AWSCluster",
+							Namespace:  namespace,
+							Name:       ClusterName,
+							APIVersion: "infrastructure.cluster.x-k8s.io/v1beta2",
+						},
+					},
+				}
+				err := k8sClient.Create(ctx, cluster)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			When("there are still ec2 instances from karpenter", func() {
+				BeforeEach(func() {
+					ec2Client.GetNonTerminatedInstancesByTagReturnsOnCall(0, []string{"i-abc123", "i-def456"}, nil)
+				})
+
+				It("keeps the finalizer, does not terminate, and requeues", func() {
+					Expect(reconcileErr).NotTo(HaveOccurred())
+					Expect(ec2Client.GetNonTerminatedInstancesByTagCallCount()).To(Equal(1))
+					// Cluster is alive: we must not terminate behind in-WC Karpenter's back.
+					Expect(ec2Client.TerminateInstancesCallCount()).To(Equal(0))
+					Expect(reconcileResult.RequeueAfter).To(Equal(30 * time.Second))
+
+					karpenterMachinePoolList := &karpenterinfra.KarpenterMachinePoolList{}
+					err := k8sClient.List(ctx, karpenterMachinePoolList, client.InNamespace(namespace))
+					Expect(err).NotTo(HaveOccurred())
+					// Finalizer still in place because EC2 instances remain.
+					Expect(karpenterMachinePoolList.Items).To(HaveLen(1))
+				})
+			})
+
+			When("karpenter has already terminated the ec2 instances", func() {
+				BeforeEach(func() {
+					ec2Client.GetNonTerminatedInstancesByTagReturnsOnCall(0, nil, nil)
+				})
+
+				It("removes the finalizer without calling TerminateInstances", func() {
+					Expect(reconcileErr).NotTo(HaveOccurred())
+					Expect(ec2Client.GetNonTerminatedInstancesByTagCallCount()).To(Equal(1))
+					Expect(ec2Client.TerminateInstancesCallCount()).To(Equal(0))
+
+					karpenterMachinePoolList := &karpenterinfra.KarpenterMachinePoolList{}
+					err := k8sClient.List(ctx, karpenterMachinePoolList, client.InNamespace(namespace))
+					Expect(err).NotTo(HaveOccurred())
 					Expect(karpenterMachinePoolList.Items).To(HaveLen(0))
 				})
 			})

--- a/controllers/karpentermachinepool_controller_test.go
+++ b/controllers/karpentermachinepool_controller_test.go
@@ -308,19 +308,24 @@ var _ = Describe("KarpenterMachinePool reconciler", func() {
 				Expect(err).NotTo(HaveOccurred())
 			})
 			// This test is a bit cumbersome because we are deleting CRs, so we can't use different `It` blocks or the CRs would be gone.
-			// We first mock the call to `GetNonTerminatedInstancesByTag` to return some instances so that we can test
+			// We first mock the call to `GetNonTerminatedInstancesByTags` to return some instances so that we can test
 			// the behavior when there are pending instances to remove.
 			// Then we manually/explicitly call the reconciler inside the test again, to be able to test the behavior
 			// when there are no instances to remove.
 			When("there are ec2 instances from karpenter", func() {
 				BeforeEach(func() {
-					ec2Client.GetNonTerminatedInstancesByTagReturnsOnCall(0, []string{"i-abc123", "i-def456"}, nil)
+					ec2Client.GetNonTerminatedInstancesByTagsReturnsOnCall(0, []string{"i-abc123", "i-def456"}, nil)
 				})
 
 				It("terminates ec2 instances, keeps the finalizer until AWS is clean, and only then removes it", func() {
 					// First reconcile: instances still present, controller terminates them and requeues.
 					Expect(reconcileErr).NotTo(HaveOccurred())
-					Expect(ec2Client.GetNonTerminatedInstancesByTagCallCount()).To(Equal(1))
+					Expect(ec2Client.GetNonTerminatedInstancesByTagsCallCount()).To(Equal(1))
+					// The lookup must be scoped by both NodePool name AND cluster ownership,
+					// so two clusters sharing a NodePool name cannot interfere with each other.
+					_, _, tagFilters := ec2Client.GetNonTerminatedInstancesByTagsArgsForCall(0)
+					Expect(tagFilters).To(HaveKeyWithValue("karpenter.sh/nodepool", KarpenterMachinePoolName))
+					Expect(tagFilters).To(HaveKeyWithValue("giantswarm.io/cluster", ClusterName))
 					Expect(ec2Client.TerminateInstancesCallCount()).To(Equal(1))
 					_, _, terminatedIDs := ec2Client.TerminateInstancesArgsForCall(0)
 					Expect(terminatedIDs).To(ConsistOf("i-abc123", "i-def456"))
@@ -333,7 +338,7 @@ var _ = Describe("KarpenterMachinePool reconciler", func() {
 					Expect(karpenterMachinePoolList.Items).To(HaveLen(1))
 
 					// Second reconcile: AWS reports zero non-terminated instances, controller removes the finalizer.
-					ec2Client.GetNonTerminatedInstancesByTagReturnsOnCall(1, nil, nil)
+					ec2Client.GetNonTerminatedInstancesByTagsReturnsOnCall(1, nil, nil)
 
 					reconcileResult, reconcileErr = reconciler.Reconcile(ctx, ctrl.Request{
 						NamespacedName: types.NamespacedName{
@@ -342,7 +347,7 @@ var _ = Describe("KarpenterMachinePool reconciler", func() {
 						},
 					})
 
-					Expect(ec2Client.GetNonTerminatedInstancesByTagCallCount()).To(Equal(2))
+					Expect(ec2Client.GetNonTerminatedInstancesByTagsCallCount()).To(Equal(2))
 					// TerminateInstances was not called again because the list was empty.
 					Expect(ec2Client.TerminateInstancesCallCount()).To(Equal(1))
 
@@ -386,12 +391,12 @@ var _ = Describe("KarpenterMachinePool reconciler", func() {
 
 			When("there are still ec2 instances from karpenter", func() {
 				BeforeEach(func() {
-					ec2Client.GetNonTerminatedInstancesByTagReturnsOnCall(0, []string{"i-abc123", "i-def456"}, nil)
+					ec2Client.GetNonTerminatedInstancesByTagsReturnsOnCall(0, []string{"i-abc123", "i-def456"}, nil)
 				})
 
 				It("keeps the finalizer, does not terminate, and requeues", func() {
 					Expect(reconcileErr).NotTo(HaveOccurred())
-					Expect(ec2Client.GetNonTerminatedInstancesByTagCallCount()).To(Equal(1))
+					Expect(ec2Client.GetNonTerminatedInstancesByTagsCallCount()).To(Equal(1))
 					// Cluster is alive: we must not terminate behind in-WC Karpenter's back.
 					Expect(ec2Client.TerminateInstancesCallCount()).To(Equal(0))
 					Expect(reconcileResult.RequeueAfter).To(Equal(30 * time.Second))
@@ -406,12 +411,12 @@ var _ = Describe("KarpenterMachinePool reconciler", func() {
 
 			When("karpenter has already terminated the ec2 instances", func() {
 				BeforeEach(func() {
-					ec2Client.GetNonTerminatedInstancesByTagReturnsOnCall(0, nil, nil)
+					ec2Client.GetNonTerminatedInstancesByTagsReturnsOnCall(0, nil, nil)
 				})
 
 				It("removes the finalizer without calling TerminateInstances", func() {
 					Expect(reconcileErr).NotTo(HaveOccurred())
-					Expect(ec2Client.GetNonTerminatedInstancesByTagCallCount()).To(Equal(1))
+					Expect(ec2Client.GetNonTerminatedInstancesByTagsCallCount()).To(Equal(1))
 					Expect(ec2Client.TerminateInstancesCallCount()).To(Equal(0))
 
 					karpenterMachinePoolList := &karpenterinfra.KarpenterMachinePoolList{}

--- a/pkg/aws/ec2client.go
+++ b/pkg/aws/ec2client.go
@@ -162,22 +162,28 @@ func getEc2Tags(t map[string]string) []ec2types.Tag {
 	return tags
 }
 
-// GetNonTerminatedInstancesByTag returns the IDs of EC2 instances matching the given
-// tag that are NOT in the `terminated` state (i.e., still in pending, running, shutting-down,
-// stopping or stopped). Callers use this to decide whether finalizer removal is safe:
-// while the result is non-empty, AWS still has matching resources backing live ENIs.
-func (a *AWSEC2) GetNonTerminatedInstancesByTag(ctx context.Context, logger logr.Logger, tagKey, tagValue string) ([]string, error) {
-	logger.Info("Finding EC2 instances with tag", "tagKey", tagKey, "tagValue", tagValue)
+// GetNonTerminatedInstancesByTags returns the IDs of EC2 instances that carry ALL of the
+// given tag key/value pairs and are NOT in the `terminated` state (i.e., still in pending,
+// running, shutting-down, stopping or stopped). Multiple `tag:` filters are ANDed by the
+// EC2 API. Callers use this to decide whether finalizer removal is safe: while the result
+// is non-empty, AWS still has matching resources backing live ENIs.
+func (a *AWSEC2) GetNonTerminatedInstancesByTags(ctx context.Context, logger logr.Logger, tags map[string]string) ([]string, error) {
+	if len(tags) == 0 {
+		return nil, errors.New("at least one tag filter is required")
+	}
 
-	filter := []ec2types.Filter{
-		{
-			Name:   aws.String("tag:" + tagKey),
-			Values: []string{tagValue},
-		},
+	logger.Info("Finding EC2 instances with tags", "tags", tags)
+
+	filters := make([]ec2types.Filter, 0, len(tags))
+	for k, v := range tags {
+		filters = append(filters, ec2types.Filter{
+			Name:   aws.String("tag:" + k),
+			Values: []string{v},
+		})
 	}
 
 	resp, err := a.client.DescribeInstances(ctx, &ec2.DescribeInstancesInput{
-		Filters: filter,
+		Filters: filters,
 	})
 	if err != nil {
 		return nil, errors.WithStack(err)
@@ -192,7 +198,7 @@ func (a *AWSEC2) GetNonTerminatedInstancesByTag(ctx context.Context, logger logr
 		}
 	}
 
-	logger.Info("Found non-terminated instances", "count", len(instanceIDs), "tagKey", tagKey, "tagValue", tagValue)
+	logger.Info("Found non-terminated instances", "count", len(instanceIDs), "tags", tags)
 	return instanceIDs, nil
 }
 

--- a/pkg/aws/ec2client.go
+++ b/pkg/aws/ec2client.go
@@ -162,13 +162,13 @@ func getEc2Tags(t map[string]string) []ec2types.Tag {
 	return tags
 }
 
-// TerminateInstancesByTag terminates all EC2 instances that have the specified tag key and value.
-func (a *AWSEC2) TerminateInstancesByTag(ctx context.Context, logger logr.Logger, tagKey, tagValue string) ([]string, error) {
-	ids := []string{}
-
+// GetNonTerminatedInstancesByTag returns the IDs of EC2 instances matching the given
+// tag that are NOT in the `terminated` state (i.e., still in pending, running, shutting-down,
+// stopping or stopped). Callers use this to decide whether finalizer removal is safe:
+// while the result is non-empty, AWS still has matching resources backing live ENIs.
+func (a *AWSEC2) GetNonTerminatedInstancesByTag(ctx context.Context, logger logr.Logger, tagKey, tagValue string) ([]string, error) {
 	logger.Info("Finding EC2 instances with tag", "tagKey", tagKey, "tagValue", tagValue)
 
-	// Create filter for the tag
 	filter := []ec2types.Filter{
 		{
 			Name:   aws.String("tag:" + tagKey),
@@ -176,43 +176,40 @@ func (a *AWSEC2) TerminateInstancesByTag(ctx context.Context, logger logr.Logger
 		},
 	}
 
-	// Describe instances with the tag
 	resp, err := a.client.DescribeInstances(ctx, &ec2.DescribeInstancesInput{
 		Filters: filter,
-	})
-	if err != nil {
-		return ids, errors.WithStack(err)
-	}
-
-	// Collect instance IDs
-	var instanceIds []string
-	for _, reservation := range resp.Reservations {
-		for _, instance := range reservation.Instances {
-			// Only include running or pending instances
-			if instance.State.Name == ec2types.InstanceStateNameRunning || instance.State.Name == ec2types.InstanceStateNamePending {
-				logger.Info("Found instance to terminate", "instanceId", *instance.InstanceId)
-				instanceIds = append(instanceIds, *instance.InstanceId)
-			}
-		}
-	}
-
-	// If no instances found, return
-	if len(instanceIds) == 0 {
-		logger.Info("No instances found with the specified tag")
-		return ids, nil
-	}
-
-	// Terminate the instances
-	logger.Info("Terminating instances", "count", len(instanceIds))
-	_, err = a.client.TerminateInstances(ctx, &ec2.TerminateInstancesInput{
-		InstanceIds: instanceIds,
 	})
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
 
-	ids = append(ids, instanceIds...)
+	var instanceIDs []string
+	for _, reservation := range resp.Reservations {
+		for _, instance := range reservation.Instances {
+			if instance.State.Name != ec2types.InstanceStateNameTerminated {
+				instanceIDs = append(instanceIDs, *instance.InstanceId)
+			}
+		}
+	}
 
-	logger.Info("Successfully requested termination of instances", "count", len(ids), "instances", ids, "tagKey", tagKey, "tagValue", tagValue)
-	return ids, nil
+	logger.Info("Found non-terminated instances", "count", len(instanceIDs), "tagKey", tagKey, "tagValue", tagValue)
+	return instanceIDs, nil
+}
+
+// TerminateInstances requests termination of the given EC2 instance IDs. Idempotent:
+// AWS accepts instance IDs that are already in the shutting-down or terminated state.
+// Returns nil and emits no AWS call when instanceIDs is empty.
+func (a *AWSEC2) TerminateInstances(ctx context.Context, logger logr.Logger, instanceIDs []string) error {
+	if len(instanceIDs) == 0 {
+		return nil
+	}
+
+	logger.Info("Requesting termination of instances", "count", len(instanceIDs), "instances", instanceIDs)
+	_, err := a.client.TerminateInstances(ctx, &ec2.TerminateInstancesInput{
+		InstanceIds: instanceIDs,
+	})
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	return nil
 }

--- a/pkg/aws/ec2client.go
+++ b/pkg/aws/ec2client.go
@@ -182,18 +182,23 @@ func (a *AWSEC2) GetNonTerminatedInstancesByTags(ctx context.Context, logger log
 		})
 	}
 
-	resp, err := a.client.DescribeInstances(ctx, &ec2.DescribeInstancesInput{
+	var instanceIDs []string
+	paginator := ec2.NewDescribeInstancesPaginator(a.client, &ec2.DescribeInstancesInput{
 		Filters: filters,
 	})
-	if err != nil {
-		return nil, errors.WithStack(err)
-	}
-
-	var instanceIDs []string
-	for _, reservation := range resp.Reservations {
-		for _, instance := range reservation.Instances {
-			if instance.State.Name != ec2types.InstanceStateNameTerminated {
-				instanceIDs = append(instanceIDs, *instance.InstanceId)
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
+		if err != nil {
+			return nil, errors.WithStack(err)
+		}
+		for _, reservation := range page.Reservations {
+			for _, instance := range reservation.Instances {
+				if instance.InstanceId == nil || instance.State == nil {
+					continue
+				}
+				if instance.State.Name != ec2types.InstanceStateNameTerminated {
+					instanceIDs = append(instanceIDs, *instance.InstanceId)
+				}
 			}
 		}
 	}

--- a/pkg/resolver/package.go
+++ b/pkg/resolver/package.go
@@ -26,10 +26,12 @@ type AWSClients interface {
 type EC2Client interface {
 	CreateSecurityGroupForResolverEndpoints(ctx context.Context, vpcId, groupName string, tags map[string]string) (string, error)
 	DeleteSecurityGroupForResolverEndpoints(ctx context.Context, logger logr.Logger, vpcId, groupName string) error
-	// GetNonTerminatedInstancesByTag returns the IDs of EC2 instances matching the given tag
-	// that are not in the `terminated` state. Used by callers to gate finalizer removal on
-	// AWS-side state (i.e., keep the finalizer until AWS confirms zero matching instances).
-	GetNonTerminatedInstancesByTag(ctx context.Context, logger logr.Logger, tagKey, tagValue string) ([]string, error)
+	// GetNonTerminatedInstancesByTags returns the IDs of EC2 instances that carry ALL of
+	// the given tag key/value pairs and are not in the `terminated` state. Callers should
+	// scope the match by both pool identity and cluster ownership so node-pool name
+	// collisions across clusters cannot cause the operator to touch the wrong instances.
+	// Used to gate finalizer removal on AWS-side state.
+	GetNonTerminatedInstancesByTags(ctx context.Context, logger logr.Logger, tags map[string]string) ([]string, error)
 	// TerminateInstances requests termination of the given EC2 instance IDs. The call is
 	// idempotent: instances already terminating are accepted by the AWS API.
 	TerminateInstances(ctx context.Context, logger logr.Logger, instanceIDs []string) error

--- a/pkg/resolver/package.go
+++ b/pkg/resolver/package.go
@@ -26,7 +26,13 @@ type AWSClients interface {
 type EC2Client interface {
 	CreateSecurityGroupForResolverEndpoints(ctx context.Context, vpcId, groupName string, tags map[string]string) (string, error)
 	DeleteSecurityGroupForResolverEndpoints(ctx context.Context, logger logr.Logger, vpcId, groupName string) error
-	TerminateInstancesByTag(ctx context.Context, logger logr.Logger, tagKey, tagValue string) ([]string, error)
+	// GetNonTerminatedInstancesByTag returns the IDs of EC2 instances matching the given tag
+	// that are not in the `terminated` state. Used by callers to gate finalizer removal on
+	// AWS-side state (i.e., keep the finalizer until AWS confirms zero matching instances).
+	GetNonTerminatedInstancesByTag(ctx context.Context, logger logr.Logger, tagKey, tagValue string) ([]string, error)
+	// TerminateInstances requests termination of the given EC2 instance IDs. The call is
+	// idempotent: instances already terminating are accepted by the AWS API.
+	TerminateInstances(ctx context.Context, logger logr.Logger, instanceIDs []string) error
 }
 
 type ResourceShare struct {

--- a/pkg/resolver/resolverfakes/fake_ec2client.go
+++ b/pkg/resolver/resolverfakes/fake_ec2client.go
@@ -40,19 +40,18 @@ type FakeEC2Client struct {
 	deleteSecurityGroupForResolverEndpointsReturnsOnCall map[int]struct {
 		result1 error
 	}
-	GetNonTerminatedInstancesByTagStub        func(context.Context, logr.Logger, string, string) ([]string, error)
-	getNonTerminatedInstancesByTagMutex       sync.RWMutex
-	getNonTerminatedInstancesByTagArgsForCall []struct {
+	GetNonTerminatedInstancesByTagsStub        func(context.Context, logr.Logger, map[string]string) ([]string, error)
+	getNonTerminatedInstancesByTagsMutex       sync.RWMutex
+	getNonTerminatedInstancesByTagsArgsForCall []struct {
 		arg1 context.Context
 		arg2 logr.Logger
-		arg3 string
-		arg4 string
+		arg3 map[string]string
 	}
-	getNonTerminatedInstancesByTagReturns struct {
+	getNonTerminatedInstancesByTagsReturns struct {
 		result1 []string
 		result2 error
 	}
-	getNonTerminatedInstancesByTagReturnsOnCall map[int]struct {
+	getNonTerminatedInstancesByTagsReturnsOnCall map[int]struct {
 		result1 []string
 		result2 error
 	}
@@ -204,21 +203,20 @@ func (fake *FakeEC2Client) DeleteSecurityGroupForResolverEndpointsReturnsOnCall(
 	}{result1}
 }
 
-func (fake *FakeEC2Client) GetNonTerminatedInstancesByTag(arg1 context.Context, arg2 logr.Logger, arg3 string, arg4 string) ([]string, error) {
-	fake.getNonTerminatedInstancesByTagMutex.Lock()
-	ret, specificReturn := fake.getNonTerminatedInstancesByTagReturnsOnCall[len(fake.getNonTerminatedInstancesByTagArgsForCall)]
-	fake.getNonTerminatedInstancesByTagArgsForCall = append(fake.getNonTerminatedInstancesByTagArgsForCall, struct {
+func (fake *FakeEC2Client) GetNonTerminatedInstancesByTags(arg1 context.Context, arg2 logr.Logger, arg3 map[string]string) ([]string, error) {
+	fake.getNonTerminatedInstancesByTagsMutex.Lock()
+	ret, specificReturn := fake.getNonTerminatedInstancesByTagsReturnsOnCall[len(fake.getNonTerminatedInstancesByTagsArgsForCall)]
+	fake.getNonTerminatedInstancesByTagsArgsForCall = append(fake.getNonTerminatedInstancesByTagsArgsForCall, struct {
 		arg1 context.Context
 		arg2 logr.Logger
-		arg3 string
-		arg4 string
-	}{arg1, arg2, arg3, arg4})
-	stub := fake.GetNonTerminatedInstancesByTagStub
-	fakeReturns := fake.getNonTerminatedInstancesByTagReturns
-	fake.recordInvocation("GetNonTerminatedInstancesByTag", []interface{}{arg1, arg2, arg3, arg4})
-	fake.getNonTerminatedInstancesByTagMutex.Unlock()
+		arg3 map[string]string
+	}{arg1, arg2, arg3})
+	stub := fake.GetNonTerminatedInstancesByTagsStub
+	fakeReturns := fake.getNonTerminatedInstancesByTagsReturns
+	fake.recordInvocation("GetNonTerminatedInstancesByTags", []interface{}{arg1, arg2, arg3})
+	fake.getNonTerminatedInstancesByTagsMutex.Unlock()
 	if stub != nil {
-		return stub(arg1, arg2, arg3, arg4)
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -226,46 +224,46 @@ func (fake *FakeEC2Client) GetNonTerminatedInstancesByTag(arg1 context.Context, 
 	return fakeReturns.result1, fakeReturns.result2
 }
 
-func (fake *FakeEC2Client) GetNonTerminatedInstancesByTagCallCount() int {
-	fake.getNonTerminatedInstancesByTagMutex.RLock()
-	defer fake.getNonTerminatedInstancesByTagMutex.RUnlock()
-	return len(fake.getNonTerminatedInstancesByTagArgsForCall)
+func (fake *FakeEC2Client) GetNonTerminatedInstancesByTagsCallCount() int {
+	fake.getNonTerminatedInstancesByTagsMutex.RLock()
+	defer fake.getNonTerminatedInstancesByTagsMutex.RUnlock()
+	return len(fake.getNonTerminatedInstancesByTagsArgsForCall)
 }
 
-func (fake *FakeEC2Client) GetNonTerminatedInstancesByTagCalls(stub func(context.Context, logr.Logger, string, string) ([]string, error)) {
-	fake.getNonTerminatedInstancesByTagMutex.Lock()
-	defer fake.getNonTerminatedInstancesByTagMutex.Unlock()
-	fake.GetNonTerminatedInstancesByTagStub = stub
+func (fake *FakeEC2Client) GetNonTerminatedInstancesByTagsCalls(stub func(context.Context, logr.Logger, map[string]string) ([]string, error)) {
+	fake.getNonTerminatedInstancesByTagsMutex.Lock()
+	defer fake.getNonTerminatedInstancesByTagsMutex.Unlock()
+	fake.GetNonTerminatedInstancesByTagsStub = stub
 }
 
-func (fake *FakeEC2Client) GetNonTerminatedInstancesByTagArgsForCall(i int) (context.Context, logr.Logger, string, string) {
-	fake.getNonTerminatedInstancesByTagMutex.RLock()
-	defer fake.getNonTerminatedInstancesByTagMutex.RUnlock()
-	argsForCall := fake.getNonTerminatedInstancesByTagArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
+func (fake *FakeEC2Client) GetNonTerminatedInstancesByTagsArgsForCall(i int) (context.Context, logr.Logger, map[string]string) {
+	fake.getNonTerminatedInstancesByTagsMutex.RLock()
+	defer fake.getNonTerminatedInstancesByTagsMutex.RUnlock()
+	argsForCall := fake.getNonTerminatedInstancesByTagsArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
 }
 
-func (fake *FakeEC2Client) GetNonTerminatedInstancesByTagReturns(result1 []string, result2 error) {
-	fake.getNonTerminatedInstancesByTagMutex.Lock()
-	defer fake.getNonTerminatedInstancesByTagMutex.Unlock()
-	fake.GetNonTerminatedInstancesByTagStub = nil
-	fake.getNonTerminatedInstancesByTagReturns = struct {
+func (fake *FakeEC2Client) GetNonTerminatedInstancesByTagsReturns(result1 []string, result2 error) {
+	fake.getNonTerminatedInstancesByTagsMutex.Lock()
+	defer fake.getNonTerminatedInstancesByTagsMutex.Unlock()
+	fake.GetNonTerminatedInstancesByTagsStub = nil
+	fake.getNonTerminatedInstancesByTagsReturns = struct {
 		result1 []string
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *FakeEC2Client) GetNonTerminatedInstancesByTagReturnsOnCall(i int, result1 []string, result2 error) {
-	fake.getNonTerminatedInstancesByTagMutex.Lock()
-	defer fake.getNonTerminatedInstancesByTagMutex.Unlock()
-	fake.GetNonTerminatedInstancesByTagStub = nil
-	if fake.getNonTerminatedInstancesByTagReturnsOnCall == nil {
-		fake.getNonTerminatedInstancesByTagReturnsOnCall = make(map[int]struct {
+func (fake *FakeEC2Client) GetNonTerminatedInstancesByTagsReturnsOnCall(i int, result1 []string, result2 error) {
+	fake.getNonTerminatedInstancesByTagsMutex.Lock()
+	defer fake.getNonTerminatedInstancesByTagsMutex.Unlock()
+	fake.GetNonTerminatedInstancesByTagsStub = nil
+	if fake.getNonTerminatedInstancesByTagsReturnsOnCall == nil {
+		fake.getNonTerminatedInstancesByTagsReturnsOnCall = make(map[int]struct {
 			result1 []string
 			result2 error
 		})
 	}
-	fake.getNonTerminatedInstancesByTagReturnsOnCall[i] = struct {
+	fake.getNonTerminatedInstancesByTagsReturnsOnCall[i] = struct {
 		result1 []string
 		result2 error
 	}{result1, result2}

--- a/pkg/resolver/resolverfakes/fake_ec2client.go
+++ b/pkg/resolver/resolverfakes/fake_ec2client.go
@@ -40,21 +40,34 @@ type FakeEC2Client struct {
 	deleteSecurityGroupForResolverEndpointsReturnsOnCall map[int]struct {
 		result1 error
 	}
-	TerminateInstancesByTagStub        func(context.Context, logr.Logger, string, string) ([]string, error)
-	terminateInstancesByTagMutex       sync.RWMutex
-	terminateInstancesByTagArgsForCall []struct {
+	GetNonTerminatedInstancesByTagStub        func(context.Context, logr.Logger, string, string) ([]string, error)
+	getNonTerminatedInstancesByTagMutex       sync.RWMutex
+	getNonTerminatedInstancesByTagArgsForCall []struct {
 		arg1 context.Context
 		arg2 logr.Logger
 		arg3 string
 		arg4 string
 	}
-	terminateInstancesByTagReturns struct {
+	getNonTerminatedInstancesByTagReturns struct {
 		result1 []string
 		result2 error
 	}
-	terminateInstancesByTagReturnsOnCall map[int]struct {
+	getNonTerminatedInstancesByTagReturnsOnCall map[int]struct {
 		result1 []string
 		result2 error
+	}
+	TerminateInstancesStub        func(context.Context, logr.Logger, []string) error
+	terminateInstancesMutex       sync.RWMutex
+	terminateInstancesArgsForCall []struct {
+		arg1 context.Context
+		arg2 logr.Logger
+		arg3 []string
+	}
+	terminateInstancesReturns struct {
+		result1 error
+	}
+	terminateInstancesReturnsOnCall map[int]struct {
+		result1 error
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
@@ -191,19 +204,19 @@ func (fake *FakeEC2Client) DeleteSecurityGroupForResolverEndpointsReturnsOnCall(
 	}{result1}
 }
 
-func (fake *FakeEC2Client) TerminateInstancesByTag(arg1 context.Context, arg2 logr.Logger, arg3 string, arg4 string) ([]string, error) {
-	fake.terminateInstancesByTagMutex.Lock()
-	ret, specificReturn := fake.terminateInstancesByTagReturnsOnCall[len(fake.terminateInstancesByTagArgsForCall)]
-	fake.terminateInstancesByTagArgsForCall = append(fake.terminateInstancesByTagArgsForCall, struct {
+func (fake *FakeEC2Client) GetNonTerminatedInstancesByTag(arg1 context.Context, arg2 logr.Logger, arg3 string, arg4 string) ([]string, error) {
+	fake.getNonTerminatedInstancesByTagMutex.Lock()
+	ret, specificReturn := fake.getNonTerminatedInstancesByTagReturnsOnCall[len(fake.getNonTerminatedInstancesByTagArgsForCall)]
+	fake.getNonTerminatedInstancesByTagArgsForCall = append(fake.getNonTerminatedInstancesByTagArgsForCall, struct {
 		arg1 context.Context
 		arg2 logr.Logger
 		arg3 string
 		arg4 string
 	}{arg1, arg2, arg3, arg4})
-	stub := fake.TerminateInstancesByTagStub
-	fakeReturns := fake.terminateInstancesByTagReturns
-	fake.recordInvocation("TerminateInstancesByTag", []interface{}{arg1, arg2, arg3, arg4})
-	fake.terminateInstancesByTagMutex.Unlock()
+	stub := fake.GetNonTerminatedInstancesByTagStub
+	fakeReturns := fake.getNonTerminatedInstancesByTagReturns
+	fake.recordInvocation("GetNonTerminatedInstancesByTag", []interface{}{arg1, arg2, arg3, arg4})
+	fake.getNonTerminatedInstancesByTagMutex.Unlock()
 	if stub != nil {
 		return stub(arg1, arg2, arg3, arg4)
 	}
@@ -213,49 +226,117 @@ func (fake *FakeEC2Client) TerminateInstancesByTag(arg1 context.Context, arg2 lo
 	return fakeReturns.result1, fakeReturns.result2
 }
 
-func (fake *FakeEC2Client) TerminateInstancesByTagCallCount() int {
-	fake.terminateInstancesByTagMutex.RLock()
-	defer fake.terminateInstancesByTagMutex.RUnlock()
-	return len(fake.terminateInstancesByTagArgsForCall)
+func (fake *FakeEC2Client) GetNonTerminatedInstancesByTagCallCount() int {
+	fake.getNonTerminatedInstancesByTagMutex.RLock()
+	defer fake.getNonTerminatedInstancesByTagMutex.RUnlock()
+	return len(fake.getNonTerminatedInstancesByTagArgsForCall)
 }
 
-func (fake *FakeEC2Client) TerminateInstancesByTagCalls(stub func(context.Context, logr.Logger, string, string) ([]string, error)) {
-	fake.terminateInstancesByTagMutex.Lock()
-	defer fake.terminateInstancesByTagMutex.Unlock()
-	fake.TerminateInstancesByTagStub = stub
+func (fake *FakeEC2Client) GetNonTerminatedInstancesByTagCalls(stub func(context.Context, logr.Logger, string, string) ([]string, error)) {
+	fake.getNonTerminatedInstancesByTagMutex.Lock()
+	defer fake.getNonTerminatedInstancesByTagMutex.Unlock()
+	fake.GetNonTerminatedInstancesByTagStub = stub
 }
 
-func (fake *FakeEC2Client) TerminateInstancesByTagArgsForCall(i int) (context.Context, logr.Logger, string, string) {
-	fake.terminateInstancesByTagMutex.RLock()
-	defer fake.terminateInstancesByTagMutex.RUnlock()
-	argsForCall := fake.terminateInstancesByTagArgsForCall[i]
+func (fake *FakeEC2Client) GetNonTerminatedInstancesByTagArgsForCall(i int) (context.Context, logr.Logger, string, string) {
+	fake.getNonTerminatedInstancesByTagMutex.RLock()
+	defer fake.getNonTerminatedInstancesByTagMutex.RUnlock()
+	argsForCall := fake.getNonTerminatedInstancesByTagArgsForCall[i]
 	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
 }
 
-func (fake *FakeEC2Client) TerminateInstancesByTagReturns(result1 []string, result2 error) {
-	fake.terminateInstancesByTagMutex.Lock()
-	defer fake.terminateInstancesByTagMutex.Unlock()
-	fake.TerminateInstancesByTagStub = nil
-	fake.terminateInstancesByTagReturns = struct {
+func (fake *FakeEC2Client) GetNonTerminatedInstancesByTagReturns(result1 []string, result2 error) {
+	fake.getNonTerminatedInstancesByTagMutex.Lock()
+	defer fake.getNonTerminatedInstancesByTagMutex.Unlock()
+	fake.GetNonTerminatedInstancesByTagStub = nil
+	fake.getNonTerminatedInstancesByTagReturns = struct {
 		result1 []string
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *FakeEC2Client) TerminateInstancesByTagReturnsOnCall(i int, result1 []string, result2 error) {
-	fake.terminateInstancesByTagMutex.Lock()
-	defer fake.terminateInstancesByTagMutex.Unlock()
-	fake.TerminateInstancesByTagStub = nil
-	if fake.terminateInstancesByTagReturnsOnCall == nil {
-		fake.terminateInstancesByTagReturnsOnCall = make(map[int]struct {
+func (fake *FakeEC2Client) GetNonTerminatedInstancesByTagReturnsOnCall(i int, result1 []string, result2 error) {
+	fake.getNonTerminatedInstancesByTagMutex.Lock()
+	defer fake.getNonTerminatedInstancesByTagMutex.Unlock()
+	fake.GetNonTerminatedInstancesByTagStub = nil
+	if fake.getNonTerminatedInstancesByTagReturnsOnCall == nil {
+		fake.getNonTerminatedInstancesByTagReturnsOnCall = make(map[int]struct {
 			result1 []string
 			result2 error
 		})
 	}
-	fake.terminateInstancesByTagReturnsOnCall[i] = struct {
+	fake.getNonTerminatedInstancesByTagReturnsOnCall[i] = struct {
 		result1 []string
 		result2 error
 	}{result1, result2}
+}
+
+func (fake *FakeEC2Client) TerminateInstances(arg1 context.Context, arg2 logr.Logger, arg3 []string) error {
+	var arg3Copy []string
+	if arg3 != nil {
+		arg3Copy = make([]string, len(arg3))
+		copy(arg3Copy, arg3)
+	}
+	fake.terminateInstancesMutex.Lock()
+	ret, specificReturn := fake.terminateInstancesReturnsOnCall[len(fake.terminateInstancesArgsForCall)]
+	fake.terminateInstancesArgsForCall = append(fake.terminateInstancesArgsForCall, struct {
+		arg1 context.Context
+		arg2 logr.Logger
+		arg3 []string
+	}{arg1, arg2, arg3Copy})
+	stub := fake.TerminateInstancesStub
+	fakeReturns := fake.terminateInstancesReturns
+	fake.recordInvocation("TerminateInstances", []interface{}{arg1, arg2, arg3Copy})
+	fake.terminateInstancesMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeEC2Client) TerminateInstancesCallCount() int {
+	fake.terminateInstancesMutex.RLock()
+	defer fake.terminateInstancesMutex.RUnlock()
+	return len(fake.terminateInstancesArgsForCall)
+}
+
+func (fake *FakeEC2Client) TerminateInstancesCalls(stub func(context.Context, logr.Logger, []string) error) {
+	fake.terminateInstancesMutex.Lock()
+	defer fake.terminateInstancesMutex.Unlock()
+	fake.TerminateInstancesStub = stub
+}
+
+func (fake *FakeEC2Client) TerminateInstancesArgsForCall(i int) (context.Context, logr.Logger, []string) {
+	fake.terminateInstancesMutex.RLock()
+	defer fake.terminateInstancesMutex.RUnlock()
+	argsForCall := fake.terminateInstancesArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+}
+
+func (fake *FakeEC2Client) TerminateInstancesReturns(result1 error) {
+	fake.terminateInstancesMutex.Lock()
+	defer fake.terminateInstancesMutex.Unlock()
+	fake.TerminateInstancesStub = nil
+	fake.terminateInstancesReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeEC2Client) TerminateInstancesReturnsOnCall(i int, result1 error) {
+	fake.terminateInstancesMutex.Lock()
+	defer fake.terminateInstancesMutex.Unlock()
+	fake.TerminateInstancesStub = nil
+	if fake.terminateInstancesReturnsOnCall == nil {
+		fake.terminateInstancesReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.terminateInstancesReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
 }
 
 func (fake *FakeEC2Client) Invocations() map[string][][]interface{} {


### PR DESCRIPTION
## Summary

- Keep the `KarpenterMachinePool` finalizer in place until `DescribeInstances` reports zero non-terminated EC2 instances tagged with the pool's `karpenter.sh/nodepool` value, instead of relying on the parent `Cluster`'s `deletionTimestamp` being visible in the local informer cache.
- Split `TerminateInstancesByTag` into `GetNonTerminatedInstancesByTag` and `TerminateInstances` so the finalizer-removal decision (AWS-side check) is independent from issuing termination — termination still defers to in-WC Karpenter while the parent Cluster is alive.

## Why

Observed in production on the `grizzly` MC: two consecutive e2e cluster teardowns (`t-xy4w3lkieqeyix4bzm`, `t-ahmz4mn61rqwxhq7nv`) within 27h each left a handful of Karpenter-provisioned EC2 instances running in account `590184012814`/`eu-north-1` after the cluster was deleted. The instances' ENIs pinned the cluster's `node` and `lb` security groups and one private node subnet, and CAPA's `awscluster` controller looped on `DependencyViolation` forever attempting to delete them.

Forensics that ruled out alternative root causes:

- CloudTrail showed **zero `TerminateInstances` events** against the orphan instance IDs across 30 days (so AWS didn't fail to terminate — termination was never called).
- The `KarpenterMachinePool` CR was gone from the MC in both cases (so the operator's controller successfully removed its finalizer).
- The Loki log line for one of the affected reconciles (`reconcileID=dac90033-8338-4a48-8b64-a25860050db7`) shows a 3-line reconcile: `Reconciling` → `Removing finalizer` → `Done reconciling`. No `TerminateInstancesByTag`, no Karpenter-WC delete in between — the controller went straight through the `else` branch of the deletion gate.

The race comes from `helm uninstall` of the cluster-aws chart: the `Cluster` and `KarpenterMachinePool` CRs get `deletionTimestamp` set near-simultaneously, but the controller-runtime informers for the two CRDs propagate watch events independently. When the KMP-watch event fires the reconcile before the Cluster-watch update has been applied to the local cache, the gate at `controllers/karpentermachinepool_controller.go:315` evaluates as "Cluster is alive" and the controller skips EC2 termination entirely.

The old code also coupled "should I remove the finalizer?" to "is the Cluster being deleted?" rather than to AWS-side state. So once the gate misfired once, there was no second chance — the finalizer was already gone.

## What the fix does

- `reconcileDelete` always lists non-terminated EC2 instances by tag (`GetNonTerminatedInstancesByTag`) and uses that count to gate finalizer removal.
- The decision to call `TerminateInstances` ourselves is still gated on the parent Cluster's deletionTimestamp: while the cluster is alive, in-WC Karpenter is the rightful drainer (PDBs, graceful eviction); when the cluster is being deleted, Karpenter is going away with it and we must terminate the instances ourselves.
- Best-effort `deleteKarpenterResources` is moved earlier in the reconcile so the in-WC Karpenter starts disrupting NodeClaims as soon as we observe the KMP delete (was already in the common code path; now also robust to WC API being unreachable).
- The state filter inside `GetNonTerminatedInstancesByTag` includes `pending|running|shutting-down|stopping|stopped` — anything except `terminated`. The previous `pending|running`-only filter was a secondary defect that would have produced an empty list while AWS was still in `shutting-down` for several minutes.

## Test plan

- [x] `make test-unit` (265/265 controller specs pass; `go vet` clean)
- [x] New tests cover the previously-leaking path: KMP being deleted with Cluster alive, instances present → finalizer stays, `TerminateInstances` not called; same scenario with instances already gone → finalizer removed, no terminate call.
- [x] Existing test for "owner cluster is also being deleted" updated to the new contract: `GetNonTerminatedInstancesByTag` + `TerminateInstances` are both called when instances exist, and finalizer is only removed after a second reconcile reports an empty list.
- [ ] Manual repro on a dev/test installation: provision a cluster-aws release that schedules a Karpenter node, then `helm uninstall` and confirm the orphan no longer appears in AWS after the deletion completes.

## Notes

The two orphan-instance clusters that motivated this PR are still stuck. Once this lands and is deployed, the immediate cleanup is to terminate the leftover instances (`i-0616cf06132b8ff07`, `i-00ed59f020da39ccc`, `i-0d4764d882a3d7f47`, `i-0d5f9151bf2a651db` — all in `590184012814` / `eu-north-1`) so CAPA can finish the AWSCluster deletions.