### PR TITLE
build: Use split-china-push for images to increase build and deployment reliability

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,6 +88,7 @@ workflows:
     - architect/push-to-registries:
         context: architect
         name: push-to-registries
+        split-china-push: true
         requires:
         - go-build
         - unit-tests


### PR DESCRIPTION
### What this PR does / why we need it

v0.27.1 had failed to deploy at first because the image couldn't be pushed to China. This should improve the situation.

### Checklist

- [ ] Update changelog in CHANGELOG.md.
